### PR TITLE
dockerfile: Refactor container cleaning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
+!clean.sh
 !run.sh
 !my.cnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.9
-MAINTAINER Johan Bergström <bugs@bergstroem.nu>
 
 # Build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL maintainer="Johan Bergström <bugs@bergstroem.nu>" \
+      org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="mariadb-alpine" \
       org.label-schema.description="A MariaDB container suitable for development" \
       org.label-schema.vcs-ref=$VCS_REF \
@@ -12,23 +12,17 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0.0-rc.1" \
       org.label-schema.license="Apache-2.0"
 
-RUN apk add --no-cache mariadb=10.3.15-r0 \
-  && rm -rf /etc/my.cnf.d /usr/data/test/db.opt /usr/share/mariadb/README* \
-     /usr/share/mariadb/COPYING* /usr/share/mariadb/*.cnf /usr/share/terminfo \
-     /usr/share/mariadb/{binary-configure,mysqld_multi.server,mysql-log-rotate,mysql.server,install_spider.sql} \
-  && find /usr/share/mariadb/ -mindepth 1 -type d ! -name 'charsets' ! -name 'english' -print0 | xargs -0 rm -rf \
-  && touch /usr/share/mariadb/mysql_system_tables_data.sql \
-  && mkdir /run/mysqld \
-  && chown mysql:mysql /run/mysqld \
-  && for p in aria* myisam* mysqld_* innochecksum \
-              mysqlslap replace wsrep* msql2mysql sst_dump \
-              resolve_stack_dump mysqlbinlog myrocks_hotbackup test-connect-t \
-              $(cd /usr/bin; ls mysql_*| grep -v mysql_install_db); \
-              do eval rm /usr/bin/${p}; done
+# We need to keep cache since `clean.sh` uses `apk show` until its finished
+# hadolint ignore=DL3019 
+RUN apk add mariadb=10.3.15-r0
+RUN mkdir /run/mysqld && chown mysql:mysql /run/mysqld
 
-COPY run.sh /run.sh
+COPY clean.sh /tmp/clean.sh
+RUN /tmp/clean.sh && rm -rf /tmp/clean.sh /var/cache/apk /usr/share/apk
+
+COPY run.sh /usr/local/bin/start
 COPY my.cnf /etc/
 
 VOLUME ["/var/lib/mysql"]
-ENTRYPOINT ["/run.sh"]
+ENTRYPOINT ["start"]
 EXPOSE 3306

--- a/clean.sh
+++ b/clean.sh
@@ -43,9 +43,6 @@ FILES="$(apk info -L mariadb | tail -n +2 | grep -v -E "${KEEP}")
 	   ${PLUGINS}
 	   ${GENERAL}"
 
-# 	   $(apk info -L mariadb-common | tail -n +2 | grep -v -E \'"$(echo ${KEEP})"\')
-
-
 # Finally, remove it all.
 #
 # Note: some path in packages are not absolute. By using readlink

--- a/clean.sh
+++ b/clean.sh
@@ -16,13 +16,13 @@ GENERAL="
 # Pointless plugins we want to remove because they're somewhat
 # bigger than most other ones. Also, remove examples
 PLUGINS="
-    /usr/lib/mariadb/plugin/dialog_examples.so
-    /usr/lib/mariadb/plugin/example_key_management.so
+	/usr/lib/mariadb/plugin/dialog_examples.so
+	/usr/lib/mariadb/plugin/example_key_management.so
 	/usr/lib/mariadb/plugin/ha_connect.so
 	/usr/lib/mariadb/plugin/ha_example
-    /usr/lib/mariadb/plugin/ha_spider.so
-    /usr/lib/mariadb/plugin/handlersocket.so
-    /usr/lib/mariadb/plugin/libdaemon_example.so"
+	/usr/lib/mariadb/plugin/ha_spider.so
+	/usr/lib/mariadb/plugin/handlersocket.so
+	/usr/lib/mariadb/plugin/libdaemon_example.so"
 
 # Things we'd like to keep. Double sed since busybox sed doesn't seem to
 # support '2g' which would skip the first match.
@@ -41,8 +41,7 @@ KEEP=$(echo "usr/bin/mysqld
 	usr/share/mariadb/errmsg-utf8.txt
 	usr/lib/mariadb" | sed -e 's/usr/|usr/g' -e 's/^.//' | tr -d " \t\n\r")
 
-
-# Retrieve a list of files from `apk`, remove the header and finally 
+# Retrieve a list of files from `apk`, remove the header and finally
 # exclude files/folders in $KEEP
 FILES="$(apk info -L mariadb | tail -n +2 | grep -v -E "${KEEP}")
 	$(apk info -L mariadb-common | tail -n +2 | grep -v -E "${KEEP}")
@@ -60,5 +59,5 @@ for path in ${FILES}; do
 done
 
 # Replace resolveip with a oneliner to shave some size
-printf "#!/bin/sh\necho \"IP address of \${1} is 127.0.0.1\"" > /usr/bin/resolveip
+printf "#!/bin/sh\necho \"IP address of \${1} is 127.0.0.1\"" >/usr/bin/resolveip
 chmod +x /usr/bin/resolveip

--- a/clean.sh
+++ b/clean.sh
@@ -7,8 +7,8 @@ set -eo pipefail
 # Use `apk` to list package contents and selectively choose what we want
 #
 
-# General stuff that can go. mysqld_safe gets picked up by grep;
-# not sure how to work around this
+# General stuff that can go. `mysqld_safe` gets picked up by grep;
+# so we need to remove it manually. Not sure how to work around this.
 GENERAL="/usr/share/terminfo
 	/usr/bin/mysqld_safe"
 
@@ -55,3 +55,7 @@ cd /
 for path in ${FILES}; do
 	eval rm -rf "$(readlink -f "${path}")"
 done
+
+# Replace resolveip with a oneliner to shave some size
+printf "#!/bin/sh\necho \"IP address of ${1} is 127.0.0.1\"" > /usr/bin/resolveip
+chmod +x /usr/bin/resolveip

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eo pipefail
+
+#
+# Clean MariaDB files we don't need
+#
+# Use `apk` to list package contents and selectively choose what we want
+#
+
+# General stuff that can go. mysqld_safe gets picked up by grep;
+# not sure how to work around this
+GENERAL="/usr/share/terminfo
+	/usr/bin/mysqld_safe"
+
+# Pointless plugins we want to remove because they're somewhat
+# bigger than most other ones, as well as config filews
+# we maintain separately
+PLUGINS="/usr/lib/mariadb/plugin/ha_connect.so
+    /usr/lib/mariadb/plugin/ha_spider.so"
+
+# Things we'd like to keep. Double sed since busybox sed doesn't seem to
+# support '2g' which would skip the first match.
+KEEP=$(echo "usr/bin/mysqld
+	  usr/bin/getconf
+	  usr/bin/getent
+	  usr/bin/my_print_defaults
+	  usr/bin/mysql_install_db
+	  usr/share/mariadb/charsets
+	  usr/share/mariadb/english
+	  usr/share/mariadb/fill_help_tables.sql
+	  usr/share/mariadb/maria_add_gis_sp_bootstrap.sql
+	  usr/share/mariadb/mysql_test_db.sql
+	  usr/share/mariadb/mysql_performance_tables.sql
+	  usr/share/mariadb/mysql_system_tables.sql
+	  usr/share/mariadb/errmsg-utf8.txt
+	  usr/lib/mariadb" | sed -e 's/usr/|usr/g' -e 's/^.//' | tr -d " \t\n\r")
+
+
+# Retrieve a list of files from `apk`, remove the header and finally 
+# exclude files/folders in $KEEP
+FILES="$(apk info -L mariadb | tail -n +2 | grep -v -E "${KEEP}")
+	   $(apk info -L mariadb-common | tail -n +2 | grep -v -E "${KEEP}")
+	   ${PLUGINS}
+	   ${GENERAL}"
+
+# 	   $(apk info -L mariadb-common | tail -n +2 | grep -v -E \'"$(echo ${KEEP})"\')
+
+
+# Finally, remove it all.
+#
+# Note: some path in packages are not absolute. By using readlink
+# we either get full path to a file/directory or nothing at all
+# echo:ing the content makes output more loop-friendly
+cd /
+for path in ${FILES}; do
+	eval rm -rf "$(readlink -f "${path}")"
+done

--- a/clean.sh
+++ b/clean.sh
@@ -19,7 +19,7 @@ PLUGINS="
     /usr/lib/mariadb/plugin/dialog_examples.so
     /usr/lib/mariadb/plugin/example_key_management.so
 	/usr/lib/mariadb/plugin/ha_connect.so
-    /usr/lib/mariadb/plugin/ha_example
+	/usr/lib/mariadb/plugin/ha_example
     /usr/lib/mariadb/plugin/ha_spider.so
     /usr/lib/mariadb/plugin/handlersocket.so
     /usr/lib/mariadb/plugin/libdaemon_example.so"

--- a/clean.sh
+++ b/clean.sh
@@ -9,39 +9,45 @@ set -eo pipefail
 
 # General stuff that can go. `mysqld_safe` gets picked up by grep;
 # so we need to remove it manually. Not sure how to work around this.
-GENERAL="/usr/share/terminfo
+GENERAL="
+	/usr/share/terminfo
 	/usr/bin/mysqld_safe"
 
 # Pointless plugins we want to remove because they're somewhat
-# bigger than most other ones, as well as config filews
-# we maintain separately
-PLUGINS="/usr/lib/mariadb/plugin/ha_connect.so
-    /usr/lib/mariadb/plugin/ha_spider.so"
+# bigger than most other ones. Also, remove examples
+PLUGINS="
+    /usr/lib/mariadb/plugin/dialog_examples.so
+    /usr/lib/mariadb/plugin/example_key_management.so
+	/usr/lib/mariadb/plugin/ha_connect.so
+    /usr/lib/mariadb/plugin/ha_example
+    /usr/lib/mariadb/plugin/ha_spider.so
+    /usr/lib/mariadb/plugin/handlersocket.so
+    /usr/lib/mariadb/plugin/libdaemon_example.so"
 
 # Things we'd like to keep. Double sed since busybox sed doesn't seem to
 # support '2g' which would skip the first match.
 KEEP=$(echo "usr/bin/mysqld
-	  usr/bin/getconf
-	  usr/bin/getent
-	  usr/bin/my_print_defaults
-	  usr/bin/mysql_install_db
-	  usr/share/mariadb/charsets
-	  usr/share/mariadb/english
-	  usr/share/mariadb/fill_help_tables.sql
-	  usr/share/mariadb/maria_add_gis_sp_bootstrap.sql
-	  usr/share/mariadb/mysql_test_db.sql
-	  usr/share/mariadb/mysql_performance_tables.sql
-	  usr/share/mariadb/mysql_system_tables.sql
-	  usr/share/mariadb/errmsg-utf8.txt
-	  usr/lib/mariadb" | sed -e 's/usr/|usr/g' -e 's/^.//' | tr -d " \t\n\r")
+	usr/bin/getconf
+	usr/bin/getent
+	usr/bin/my_print_defaults
+	usr/bin/mysql_install_db
+	usr/share/mariadb/charsets
+	usr/share/mariadb/english
+	usr/share/mariadb/fill_help_tables.sql
+	usr/share/mariadb/maria_add_gis_sp_bootstrap.sql
+	usr/share/mariadb/mysql_test_db.sql
+	usr/share/mariadb/mysql_performance_tables.sql
+	usr/share/mariadb/mysql_system_tables.sql
+	usr/share/mariadb/errmsg-utf8.txt
+	usr/lib/mariadb" | sed -e 's/usr/|usr/g' -e 's/^.//' | tr -d " \t\n\r")
 
 
 # Retrieve a list of files from `apk`, remove the header and finally 
 # exclude files/folders in $KEEP
 FILES="$(apk info -L mariadb | tail -n +2 | grep -v -E "${KEEP}")
-	   $(apk info -L mariadb-common | tail -n +2 | grep -v -E "${KEEP}")
-	   ${PLUGINS}
-	   ${GENERAL}"
+	$(apk info -L mariadb-common | tail -n +2 | grep -v -E "${KEEP}")
+	${PLUGINS}
+	${GENERAL}"
 
 # Finally, remove it all.
 #

--- a/clean.sh
+++ b/clean.sh
@@ -54,5 +54,5 @@ for path in ${FILES}; do
 done
 
 # Replace resolveip with a oneliner to shave some size
-printf "#!/bin/sh\necho \"IP address of ${1} is 127.0.0.1\"" > /usr/bin/resolveip
+printf "#!/bin/sh\necho \"IP address of \${1} is 127.0.0.1\"" > /usr/bin/resolveip
 chmod +x /usr/bin/resolveip

--- a/run.sh
+++ b/run.sh
@@ -5,8 +5,8 @@ touch /tmp/init
 
 # This needs to be run both for initialization and general startup
 [ -n "${SKIP_INNODB}" ] || [ -f "/var/lib/mysql/noinnodb" ] &&
-  sed -i -e '/\[mariadb\]/a skip_innodb = yes\ndefault_storage_engine = MyISAM\ndefault_tmp_storage_engine = MyISAM' \
-         -e '/^innodb/d' /etc/my.cnf
+	sed -i -e '/\[mariadb\]/a skip_innodb = yes\ndefault_storage_engine = MyISAM\ndefault_tmp_storage_engine = MyISAM' \
+		-e '/^innodb/d' /etc/my.cnf
 
 MYSQLD_OPTS="--user=mysql"
 MYSQLD_OPTS="${MYSQLD_OPTS} --skip-name-resolve"
@@ -17,72 +17,81 @@ MYSQLD_OPTS="${MYSQLD_OPTS} --debug-gdb"
 
 # No previous installation
 if [ -z "$(ls -A /var/lib/mysql/)" ]; then
-  ROOTPW="''"
-  [ -n "${SKIP_INNODB}" ] && touch /var/lib/mysql/noinnodb
-  [ -n "${MYSQL_ROOT_PASSWORD}" ] && ROOTPW="PASSWORD('${MYSQL_ROOT_PASSWORD}')"
-  echo "INSERT INTO user VALUES ('%','root',${ROOTPW},'Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'','','N', 'N','', 0);" > /usr/share/mariadb/mysql_system_tables_data.sql
+	ROOTPW="''"
+	[ -n "${SKIP_INNODB}" ] && touch /var/lib/mysql/noinnodb
+	[ -n "${MYSQL_ROOT_PASSWORD}" ] && ROOTPW="PASSWORD('${MYSQL_ROOT_PASSWORD}')"
+	echo "INSERT INTO user VALUES ('%','root',${ROOTPW},'Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'','','N', 'N','', 0);" >/usr/share/mariadb/mysql_system_tables_data.sql
 
-  INSTALL_OPTS="--user=mysql"
-  INSTALL_OPTS="${INSTALL_OPTS} --cross-bootstrap"
-  INSTALL_OPTS="${INSTALL_OPTS} --rpm"
-  # https://github.com/MariaDB/server/commit/b9f3f068
-  INSTALL_OPTS="${INSTALL_OPTS} --auth-root-authentication-method=normal"
-  INSTALL_OPTS="${INSTALL_OPTS} --skip-test-db"
-  INSTALL_OPTS="${INSTALL_OPTS} --datadir=/var/lib/mysql"
-  eval /usr/bin/mysql_install_db "${INSTALL_OPTS}"
+	INSTALL_OPTS="--user=mysql"
+	INSTALL_OPTS="${INSTALL_OPTS} --cross-bootstrap"
+	INSTALL_OPTS="${INSTALL_OPTS} --rpm"
+	# https://github.com/MariaDB/server/commit/b9f3f068
+	INSTALL_OPTS="${INSTALL_OPTS} --auth-root-authentication-method=normal"
+	INSTALL_OPTS="${INSTALL_OPTS} --skip-test-db"
+	INSTALL_OPTS="${INSTALL_OPTS} --datadir=/var/lib/mysql"
+	eval /usr/bin/mysql_install_db "${INSTALL_OPTS}"
 
-  [ -n "${MYSQL_DATABASE}" ] && echo "create database if not exists \`${MYSQL_DATABASE}\` character set utf8 collate utf8_general_ci; " >> /tmp/init
-  if [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_DATABASE}" ]; then
-    echo "grant all on \`${MYSQL_DATABASE}\`.* to '${MYSQL_USER}'@'%' identified by '${MYSQL_PASSWORD}'; " >> /tmp/init
-  fi 
-  echo "flush privileges;" >> /tmp/init
+	[ -n "${MYSQL_DATABASE}" ] && echo "create database if not exists \`${MYSQL_DATABASE}\` character set utf8 collate utf8_general_ci; " >>/tmp/init
+	if [ -n "${MYSQL_USER}" ] && [ -n "${MYSQL_DATABASE}" ]; then
+		echo "grant all on \`${MYSQL_DATABASE}\`.* to '${MYSQL_USER}'@'%' identified by '${MYSQL_PASSWORD}'; " >>/tmp/init
+	fi
+	echo "flush privileges;" >>/tmp/init
 
-  # Execute custom scripts provided by a user. This will spawn a mysqld and
-  # pass scripts to it. Since we're already up an running we might as well
-  # pass the init script and avoid it later.
-  if [ "$(ls -A /docker-entrypoint-initdb.d 2> /dev/null)" ]; then
-    # Download the mysql client since we will need it to feed data to our server.
-    # This kind of sucks but seems unavoidable since using --init-file
-    # has size restrictions:
-    #   ERROR: 1105  Boostrap file error. Query size exceeded 20000 bytes near <snip>
-    # The other option is to embed the client, but since one of the goals is to
-    # Strive for the smallest possible size, this seems to be the only option.
-    echo "init: installing mysql client"
-    apk add -q --no-cache mariadb-client
+	# Execute custom scripts provided by a user. This will spawn a mysqld and
+	# pass scripts to it. Since we're already up an running we might as well
+	# pass the init script and avoid it later.
+	if [ "$(ls -A /docker-entrypoint-initdb.d 2>/dev/null)" ]; then
+		# Download the mysql client since we will need it to feed data to our server.
+		# This kind of sucks but seems unavoidable since using --init-file
+		# has size restrictions:
+		#   ERROR: 1105  Boostrap file error. Query size exceeded 20000 bytes near <snip>
+		# The other option is to embed the client, but since one of the goals is to
+		# Strive for the smallest possible size, this seems to be the only option.
+		echo "init: installing mysql client"
+		apk add -q --no-cache mariadb-client
 
-    SOCKET="/run/mysqld/mysql.sock"
-    MYSQL_CMD="mysql --protocol=socket -u root -h localhost --socket=${SOCKET}"
+		SOCKET="/run/mysqld/mysql.sock"
+		MYSQL_CMD="mysql --protocol=socket -u root -h localhost --socket=${SOCKET}"
 
-    # Start a mysqld we will use to pass init stuff to
-    mysqld --user=mysql --silent-startup --skip-networking --socket=${SOCKET} > /dev/null 2>&1 &
-    PID="$!"
+		# Start a mysqld we will use to pass init stuff to
+		mysqld --user=mysql --silent-startup --skip-networking --socket=${SOCKET} >/dev/null 2>&1 &
+		PID="$!"
 
-    # perhaps trap this to avoid issues on slow systems?
-    sleep 1
+		# perhaps trap this to avoid issues on slow systems?
+		sleep 1
 
-    # Run the init script
-    echo "init: updating system tables"
-    eval "${MYSQL_CMD}" < /tmp/init
+		# Run the init script
+		echo "init: updating system tables"
+		eval "${MYSQL_CMD}" </tmp/init
 
-    # Default scope is our newly created database
-    MYSQL_CMD="${MYSQL_CMD} ${MYSQL_DATABASE} "
+		# Default scope is our newly created database
+		MYSQL_CMD="${MYSQL_CMD} ${MYSQL_DATABASE} "
 
-    for f in /docker-entrypoint-initdb.d/*; do
-      case "${f}" in
-        *.sh)     echo "init: executing ${f}"; sh "${f}" ;;
-        *.sql)    echo "init: adding ${f}"; eval "${MYSQL_CMD}" < "$f" ;;
-        *.sql.gz) echo "init: adding ${f}"; gunzip -c "$f" | eval "${MYSQL_CMD}" ;;
-        *)        echo "init: ignoring ${f}: not a recognized format" ;;
-      esac
-    done
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "${f}" in
+			*.sh)
+				echo "init: executing ${f}"
+				sh "${f}"
+				;;
+			*.sql)
+				echo "init: adding ${f}"
+				eval "${MYSQL_CMD}" <"$f"
+				;;
+			*.sql.gz)
+				echo "init: adding ${f}"
+				gunzip -c "$f" | eval "${MYSQL_CMD}"
+				;;
+			*) echo "init: ignoring ${f}: not a recognized format" ;;
+			esac
+		done
 
-    # Clean up
-    kill -s TERM "${PID}"
-    echo "init: removing mysql client"
-    apk del -q --no-cache mariadb-client
-  else
-    MYSQLD_OPTS="${MYSQLD_OPTS} --init-file=/tmp/init"
-  fi
+		# Clean up
+		kill -s TERM "${PID}"
+		echo "init: removing mysql client"
+		apk del -q --no-cache mariadb-client
+	else
+		MYSQLD_OPTS="${MYSQLD_OPTS} --init-file=/tmp/init"
+	fi
 fi
 
 eval /usr/bin/mysqld "${MYSQLD_OPTS}"


### PR DESCRIPTION
Split out cleaning the container into a separate script that simplifies running lint (shellcheck) against it.
Also, validate `Dockerfile` (hadolint). These should soon be run as CI jobs.

Instead of manually listing files, we now use the file listing provided by `apk info -L mariadb{-common}` to instead say what we want to keep. This is a much more aggressive approach but will improve one of our top priorities - container size. The tradeoff is a potentially more unstable container which will be mitigated by both using linters in CI as well as a simple e2e suite. This means that a few plugins and other binaries are also now removed.

Also, refactor the layers in `Dockerfile` to be more developer (read: container development) friendly.

Since this potentially can break stuff I would appreciate user (cc @mauricios 😃)  testing!

#### Container size

| commit | size |
| -- | -- |
| 4ed4a1fefd (master) | 37.2M |
| ebf9e79a (this PR) | **31.8M** |

Refs: https://github.com/jbergstroem/mariadb-alpine/issues/7
Refs: https://github.com/jbergstroem/mariadb-alpine/issues/8

