### PR TITLE
Removed VOLUME in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,5 @@ USER mysql
 # Below is in my opinion better than no health check.
 HEALTHCHECK --start-period=3s CMD pgrep mysqld
 
-VOLUME ["/var/lib/mysql"]
 ENTRYPOINT ["/run.sh"]
 EXPOSE 3306

--- a/my.cnf
+++ b/my.cnf
@@ -3,9 +3,8 @@
 innodb_log_file_size = 8M
 lower_case_table_names = 1
 
-
-# Low memory settings: http://www.tocker.ca/2014/03/10/configuring-mysql-to-use-minimal-memory.html
-
+#### These optimize the memory use of MySQL
+#### http://www.tocker.ca/2014/03/10/configuring-mysql-to-use-minimal-memory.html
 innodb_buffer_pool_size=5M
 innodb_log_buffer_size=256K
 query_cache_size=0
@@ -31,3 +30,6 @@ innodb_sort_buffer_size=64K
 #settings that relate to the binary log (if enabled)
 binlog_cache_size=4K
 binlog_stmt_cache_size=4K
+
+#### from https://mariadb.com/de/node/579
+performance_schema = off

--- a/my.cnf
+++ b/my.cnf
@@ -1,4 +1,33 @@
 [mariadb]
-innodb_buffer_pool_size = 10M
+#innodb_buffer_pool_size = 10M
 innodb_log_file_size = 8M
 lower_case_table_names = 1
+
+
+# Low memory settings: http://www.tocker.ca/2014/03/10/configuring-mysql-to-use-minimal-memory.html
+
+innodb_buffer_pool_size=5M
+innodb_log_buffer_size=256K
+query_cache_size=0
+max_connections=10
+key_buffer_size=8
+thread_cache_size=0
+host_cache_size=0
+innodb_ft_cache_size=1600000
+innodb_ft_total_cache_size=32000000
+
+# per thread or per operation settings
+thread_stack=131072
+sort_buffer_size=32K
+read_buffer_size=8200
+read_rnd_buffer_size=8200
+max_heap_table_size=16K
+tmp_table_size=1K
+bulk_insert_buffer_size=0
+join_buffer_size=128
+net_buffer_length=1K
+innodb_sort_buffer_size=64K
+
+#settings that relate to the binary log (if enabled)
+binlog_cache_size=4K
+binlog_stmt_cache_size=4K


### PR DESCRIPTION
Volumes in Dockerfile are not recommended, and is a pain when using this image as base, also is the cause of #1, you can read more info about why is not recommended use VOLUME in Dockerfiles in this link: https://boxboat.com/2017/01/23/volumes-and-dockerfiles-dont-mix/