### PR TITLE
Add a test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: build
+on: pull_request
+
+jobs:
+  build:
+    name: docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: assign version for usage
+        id: assign
+        run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
+      - name: build the container
+        run: bin/build-image.sh
+        env:
+          VERSION: ${{ steps.assign.outputs.version }}
+          DOCKER_BUILDKIT: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: test
+on: pull_request
+
+jobs:
+  bats:
+    name: bats
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: assign version for usage
+        run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
+        id: assign
+      - name: build the container
+        run: bin/build-image.sh
+        env:
+          VERSION: ${{ steps.assign.outputs.version }}
+          DOCKER_BUILDKIT: 1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: install
+        run: npm install -g bats
+      - name: run suite
+        run: bats test
+        env:
+          VERSION: ${{ steps.assign.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN apk add --no-cache mariadb=10.4.13-r0 \
               $(cd /usr/bin; ls mysql_*| grep -v mysql_install_db); \
               do eval rm /usr/bin/${p}; done
 
-USER mysql
-
 # This is not super helpful; mysqld might be running but not accepting connections.
 # Since we have no clients, we can't really connect to it and check.
 #

--- a/README.md
+++ b/README.md
@@ -141,9 +141,33 @@ Version: '10.3.15-MariaDB'  socket: '/run/mysqld/mysqld.sock'  port: 3306  Maria
 
 The procedure is similar to how other containers implements it; shell scripts are executed (`.sh`), optionally compressed sql (`.sql` or `.sql.gz`) is piped to mysqld as part of it starting up. Any script or sql will use the scope of `MYSQL_DATABASE` if provided.
 
+## Testing
+
+This container image is tested with [`bats`][3] - a bash testing framework. You can find installation
+instructions in [their repository][4]. To test:
+
+```console
+$ bin/build-image.sh
+<snip>
+$ bats test
+ ✓ should output mysqld version
+ ✓ start a default server with InnoDB and no password
+ ✓ start a server without InnoDB
+ ✓ start a server with a custom root password
+ ✓ start a server with a custom database, user and password
+ ✓ verfiy that binary logging is turned off
+ ✓ should import a .sql file and execute it
+ ✓ should import a compressed file and execute it
+ ✓ should execute an imported shell script
+
+9 tests, 0 failures
+```
+
 ## License
 
 [MIT](./LICENSE).
 
 [1]: https://alpinelinux.org
 [2]: https://github.com/jbergstroem/mariadb-alpine/issues/1
+[3]: https://github.com/bats-core/bats-core
+[4]: https://github.com/bats-core/bats-core#installation

--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+IMAGE=${IMAGE:-jbergstroem/mariadb-alpine}
+SHORT_SHA=$(git rev-parse --short HEAD)
+DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERSION=${VERSION:-${SHORT_SHA}}
+
+docker image build \
+	--build-arg BUILD_DATE="${DATE}" \
+    --build-arg VCS_REF="${SHORT_SHA}" \
+    -t "${IMAGE}:${VERSION}" .

--- a/run.sh
+++ b/run.sh
@@ -87,4 +87,4 @@ if [ -z "$(ls -A /var/lib/mysql/)" ]; then
   fi
 fi
 
-/usr/bin/mysqld ${MYSQLD_OPTS}
+exec /usr/bin/mysqld ${MYSQLD_OPTS}

--- a/run.sh
+++ b/run.sh
@@ -52,10 +52,11 @@ if [ -z "$(ls -A /var/lib/mysql/)" ]; then
     echo "init: installing mysql client"
     apk add -q --no-cache mariadb-client
 
-    SOCKET="/run/mysqld/mysql.sock"
-    MYSQL_CMD="mysql --protocol=socket -u root -h localhost --socket=${SOCKET}"
+    SOCKET="/run/mysqld/mysqld.sock"
+    MYSQL_CMD="mysql"
 
-    # Start a mysqld we will use to pass init stuff to
+    # Start a mysqld we will use to pass init stuff to. Can't use the same options
+    # as a standard instance; pass them manually.
     mysqld --user=mysql --silent-startup --skip-networking --socket=${SOCKET} &> /dev/null &
     PID="$!"
 

--- a/test/01-sanity_check.bats
+++ b/test/01-sanity_check.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "should output mysqld version" {
+  run docker run --rm --entrypoint mysqld "${IMAGE}":"${VERSION}" --version
+  [[ "${status}" -eq 0 ]]
+  local grepopt
+  grepopt="-E"
+  if [[ $(uname -s) == "Linux" ]]; then
+    grepopt="-P"
+  fi
+  run grep "${grepopt}" '^mysqld\s+Ver\s+\d+\.\d+\.\d+-MariaDB*' <<< "${output}"
+  [[ "${status}" -eq 0 ]]
+}

--- a/test/02-innodb.bats
+++ b/test/02-innodb.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# InnoDB is slow to initialize; penalize this with a 5 second wait
+@test "start a default server with InnoDB and no password" {
+  local name="default-startup"
+  create ${name} ""
+  sleep 5
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e "SHOW ENGINE INNODB STATUS;"
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}

--- a/test/03-configuration.bats
+++ b/test/03-configuration.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "start a server without InnoDB" {
+  local name="skip-innodb-startup"
+  create ${name} "-e SKIP_INNODB=1"
+  sleep 2
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e "SHOW ENGINE INNODB STATUS;"
+  [[ "$status" -eq 1 ]]
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e "select 1;"
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}
+
+@test "start a server with a custom root password" {
+  local name="root-password"
+  create ${name} "-e SKIP_INNODB=1 -e MYSQL_ROOT_PASSWORD=secretsauce"
+  sleep 2
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --password=secretsauce -e "select 1;"
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}
+
+@test "start a server with a custom database, user and password" {
+  local name="custom-user-password"
+  create ${name} "-e SKIP_INNODB=1 -e MYSQL_USER=foo -e MYSQL_DATABASE=bar -e MYSQL_PASSWORD=baz"
+  sleep 2
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --user=foo --database=bar --password=baz -e "select 1;"
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}
+
+@test "verfiy that binary logging is turned off" {
+  local name="no-log-bin"
+  create ${name} "-e SKIP_INNODB=1"
+  sleep 2
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e 'select 1 where @@log_bin = 1;'
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}

--- a/test/04-import.bats
+++ b/test/04-import.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# Since we're downloading the client, wait a bit longer
+# for these tests
+
+@test "should import a .sql file and execute it" {
+  local name="sql-import"
+  local tmpdir="${BATS_TMPDIR}/${name}"
+  mkdir -p "${tmpdir}"
+  echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
+  create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
+  sleep 5
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --database=mydatabase -e "select 1;"
+  [[ "${status}" -eq 0 ]]
+  rm -rf "${tmpdir}"
+  decommission "${name}"
+}
+
+@test "should import a compressed file and execute it" {
+  local name="sql-import-gz"
+  local tmpdir="${BATS_TMPDIR}/${name}"
+  mkdir -p "${tmpdir}"
+  echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
+  gzip  "${tmpdir}/mydatabase.sql"
+  create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
+  sleep 5
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --database=mydatabase -e "select 1;"
+  [[ "${status}" -eq 0 ]]
+  rm -rf "${tmpdir}"
+  decommission "${name}"
+}
+
+@test "should execute an imported shell script" {
+  local name="sh-import"
+  local tmpdir="${BATS_TMPDIR}/${name}"
+  mkdir -p "${tmpdir}"
+  echo "mysql -e \"create database mydatabase;\"" > "${tmpdir}/custom.sh"
+  create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
+  sleep 5
+  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --database=mydatabase -e "select 1;"
+  [[ "${status}" -eq 0 ]]
+  rm -rf "${tmpdir}"
+  decommission "${name}"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+IMAGE=${IMAGE:-jbergstroem/mariadb-alpine}
+VERSION=${VERSION:-latest}
+TEST_PREFIX="mariadb-alpine-bats-test"
+
+setup() {
+  # no explanataion needed
+  run command -v docker
+  [[ "$status" -eq 0 ]]
+
+  # the test suite assumes that the image is built
+  run docker inspect "${IMAGE}":"${VERSION}"
+   [[ "$status" -eq 0 ]]
+}
+
+create() {
+  # $1: volume and container name
+  # $2: environment variables
+  run docker volume create "${TEST_PREFIX}-${1}"
+  run docker run -d --rm --name "${TEST_PREFIX}-${1}" -v "${TEST_PREFIX}-${1}":/var/lib/mysql ${2} "${IMAGE}":"${VERSION}"
+}
+
+run_with_client() {
+  # $1: query to run
+  echo foo
+}
+
+# for local testing cleaning up makes sense
+decommission() {
+  # $1: volume and container name
+  run docker stop "${TEST_PREFIX}-${1}"
+  run docker volume rm "${TEST_PREFIX}-${1}"
+}
+
+# get the ip of a running server
+get_ip() {
+  run docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${TEST_PREFIX}-${1}"
+  echo "${output}"
+}


### PR DESCRIPTION
This introduces a test suite using with [`bats`](https://github.com/bats-core/bats-core). There are still lots of things to do, but they can probably be fixed in separate work.

- Add test suite to CI
- Refactor how we invoke the client
- Move cleaning up to setup/teardown style
- Dig into how we run them in parallel; avoid the `sleep` as part of waiting for server to come up.