### PR TITLE
ci: add shell script checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: lint
+on: pull_request
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    name: shellcheck
+    steps:
+      - uses: actions/checkout@v2
+      - name: install shellcheck
+        env:
+          scversion: stable
+        run: |
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJ
+          sudo cp "shellcheck-${scversion}/shellcheck" /usr/local/bin/
+      - name: test bats suite
+        run: shellcheck -s bash test/*
+      - name: test utility scripts
+        run: shellcheck -s dash *.sh bin/*

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ touch /tmp/init
 # sed into /tmp/ since the user won't have access to create new
 # files in /etc/
 cp /tmp/my.cnf /etc/my.cnf.d/
-[[ -n "${SKIP_INNODB}" ]] || [[ -f "/var/lib/mysql/noinnodb" ]] &&
+[ -n "${SKIP_INNODB}" ] || [ -f "/var/lib/mysql/noinnodb" ] &&
   sed -i -e '/\[mariadb\]/a skip_innodb = yes\ndefault_storage_engine = MyISAM\ndefault_tmp_storage_engine = MyISAM' \
       -e '/^innodb/d' /etc/my.cnf.d/my.cnf
 
@@ -20,8 +20,8 @@ MYSQLD_OPTS="${MYSQLD_OPTS} --debug-gdb"
 
 # No previous installation
 if [ -z "$(ls -A /var/lib/mysql/)" ]; then
-  [[ -n "${SKIP_INNODB}" ]] && touch /var/lib/mysql/noinnodb
-  [[ -n "${MYSQL_ROOT_PASSWORD}" ]] && \
+  [ -n "${SKIP_INNODB}" ] && touch /var/lib/mysql/noinnodb
+  [ -n "${MYSQL_ROOT_PASSWORD}" ] && \
     echo "set password for 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');" >> /tmp/init
 
   INSTALL_OPTS="--user=mysql"
@@ -31,10 +31,10 @@ if [ -z "$(ls -A /var/lib/mysql/)" ]; then
   INSTALL_OPTS="${INSTALL_OPTS} --auth-root-authentication-method=normal"
   INSTALL_OPTS="${INSTALL_OPTS} --skip-test-db"
   INSTALL_OPTS="${INSTALL_OPTS} --datadir=/var/lib/mysql"
-  /usr/bin/mysql_install_db ${INSTALL_OPTS}
+  eval /usr/bin/mysql_install_db "${INSTALL_OPTS}"
 
-  [[ -n "${MYSQL_DATABASE}" ]] && echo "create database if not exists \`${MYSQL_DATABASE}\` character set utf8 collate utf8_general_ci; " >> /tmp/init
-  if [ -n "${MYSQL_USER}" -a -n "${MYSQL_DATABASE}" ]; then
+  [ -n "${MYSQL_DATABASE}" ] && echo "create database if not exists \`${MYSQL_DATABASE}\` character set utf8 collate utf8_general_ci; " >> /tmp/init
+  if [ -n "${MYSQL_USER}" ] && [ "${MYSQL_DATABASE}" ]; then
     echo "grant all on \`${MYSQL_DATABASE}\`.* to '${MYSQL_USER}'@'%' identified by '${MYSQL_PASSWORD}'; " >> /tmp/init
   fi 
   echo "flush privileges;" >> /tmp/init
@@ -57,7 +57,7 @@ if [ -z "$(ls -A /var/lib/mysql/)" ]; then
 
     # Start a mysqld we will use to pass init stuff to. Can't use the same options
     # as a standard instance; pass them manually.
-    mysqld --user=mysql --silent-startup --skip-networking --socket=${SOCKET} &> /dev/null &
+    mysqld --user=mysql --silent-startup --skip-networking --socket=${SOCKET} > /dev/null 2>&1 &
     PID="$!"
 
     # perhaps trap this to avoid issues on slow systems?
@@ -65,16 +65,16 @@ if [ -z "$(ls -A /var/lib/mysql/)" ]; then
 
     # Run the init script
     echo "init: updating system tables"
-    eval ${MYSQL_CMD} < /tmp/init
+    eval "${MYSQL_CMD}" < /tmp/init
 
     # Default scope is our newly created database
     MYSQL_CMD="${MYSQL_CMD} ${MYSQL_DATABASE} "
 
     for f in /docker-entrypoint-initdb.d/*; do
       case "${f}" in
-        *.sh)     echo "init: executing ${f}"; . "${f}" ;;
-        *.sql)    echo "init: adding ${f}"; eval ${MYSQL_CMD} < "$f" ;;
-        *.sql.gz) echo "init: adding ${f}"; gunzip -c "$f" | eval ${MYSQL_CMD} ;;
+        *.sh)     echo "init: executing ${f}"; /bin/sh "${f}" ;;
+        *.sql)    echo "init: adding ${f}"; eval "${MYSQL_CMD}" < "${f}" ;;
+        *.sql.gz) echo "init: adding ${f}"; gunzip -c "${f}" | eval "${MYSQL_CMD}" ;;
         *)        echo "init: ignoring ${f}: not a recognized format" ;;
       esac
     done
@@ -88,4 +88,4 @@ if [ -z "$(ls -A /var/lib/mysql/)" ]; then
   fi
 fi
 
-exec /usr/bin/mysqld ${MYSQLD_OPTS}
+eval exec /usr/bin/mysqld "${MYSQLD_OPTS}"


### PR DESCRIPTION
Use [`shellcheck`][1] to verify shell scripts.

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/8

[1]: https://www.shellcheck.net/
