### PR TITLE
test: refactor client

### DIFF
--- a/test/02-innodb.bats
+++ b/test/02-innodb.bats
@@ -7,7 +7,7 @@ load test_helper
   local name="default-startup"
   create ${name} ""
   sleep 5
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e "SHOW ENGINE INNODB STATUS;"
+  run client_query "${name}" "-e 'SHOW ENGINE INNODB STATUS;'"
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }

--- a/test/03-configuration.bats
+++ b/test/03-configuration.bats
@@ -6,9 +6,9 @@ load test_helper
   local name="skip-innodb-startup"
   create ${name} "-e SKIP_INNODB=1"
   sleep 2
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e "SHOW ENGINE INNODB STATUS;"
+  run client_query "${name}" "-e 'SHOW ENGINE INNODB STATUS;'"
   [[ "$status" -eq 1 ]]
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e "select 1;"
+  run client_query "${name}" "-e 'select 1;'"
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }
@@ -17,7 +17,16 @@ load test_helper
   local name="root-password"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_ROOT_PASSWORD=secretsauce"
   sleep 2
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --password=secretsauce -e "select 1;"
+  run client_query "${name}"  "--password=secretsauce -e 'select 1;'"
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}
+
+@test "start a server with a custom database" {
+  local name="custom-db"
+  create ${name} "-e SKIP_INNODB=1 -e MYSQL_DATABASE=bar"
+  sleep 2
+  run client_query "${name}" "--database=bar -e 'select 1;'"
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }
@@ -26,7 +35,7 @@ load test_helper
   local name="custom-user-password"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_USER=foo -e MYSQL_DATABASE=bar -e MYSQL_PASSWORD=baz"
   sleep 2
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --user=foo --database=bar --password=baz -e "select 1;"
+  run client_query "${name}" "--user=foo --database=bar --password=baz -e 'select 1;'"
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }
@@ -35,7 +44,7 @@ load test_helper
   local name="no-log-bin"
   create ${name} "-e SKIP_INNODB=1"
   sleep 2
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" -e 'select 1 where @@log_bin = 1;'
+  run client_query "${name}" "-e 'select 1 where @@log_bin = 1;'"
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }

--- a/test/04-import.bats
+++ b/test/04-import.bats
@@ -12,7 +12,7 @@ load test_helper
   echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   sleep 5
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --database=mydatabase -e "select 1;"
+  run client_query "${name}" "--database=mydatabase -e 'select 1;'"
   [[ "${status}" -eq 0 ]]
   rm -rf "${tmpdir}"
   decommission "${name}"
@@ -23,10 +23,13 @@ load test_helper
   local tmpdir="${BATS_TMPDIR}/${name}"
   mkdir -p "${tmpdir}"
   echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
+  # if you seemingly get stuck here, it's because gzip is attempting to overwrite
+  # the existing file. This means your previous run didn't execute successfully
+  # and for some reason the temp directory wasn't properly cleaned.
   gzip  "${tmpdir}/mydatabase.sql"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   sleep 5
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --database=mydatabase -e "select 1;"
+  run client_query "${name}" "--database=mydatabase -e 'select 1;'"
   [[ "${status}" -eq 0 ]]
   rm -rf "${tmpdir}"
   decommission "${name}"
@@ -39,7 +42,7 @@ load test_helper
   echo "mysql -e \"create database mydatabase;\"" > "${tmpdir}/custom.sh"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   sleep 5
-  run docker run --rm jbergstroem/mariadb-client-alpine -h "$(get_ip ${name})" --database=mydatabase -e "select 1;"
+  run client_query "${name}" "--database=mydatabase -e 'select 1;'"
   [[ "${status}" -eq 0 ]]
   rm -rf "${tmpdir}"
   decommission "${name}"


### PR DESCRIPTION
Extract how we call the client into a helper. Also, since `run.sh` branches
for database vs database/user/password, a test is added to reflect this.

Finally, remove `get_ip` since we only call it from the client.

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/21