### PR TITLE
Refactor dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !run.sh
+!clean.sh
 !my.cnf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,9 @@ jobs:
         run: shellcheck -s bash test/*
       - name: test utility scripts
         run: shellcheck -s dash *.sh bin/*
+  hadolint:
+    runs-on: ubuntu-latest
+    name: hadolint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: brpaz/hadolint-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,23 +14,15 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.license="MIT"
 
 COPY run.sh /run.sh
+COPY clean.sh /clean.sh
 COPY my.cnf /tmp/
 
-RUN apk add --no-cache mariadb=10.4.13-r0 \
-  && rm -rf /etc/my.cnf.d/* /etc/my.cnf.apk-new /usr/data/test/db.opt /usr/share/mariadb/README* \
-     /usr/share/mariadb/COPYING* /usr/share/mariadb/*.cnf /usr/share/terminfo \
-     /usr/share/mariadb/{binary-configure,mysqld_multi.server,mysql-log-rotate,mysql.server,install_spider.sql} \
-  && find /usr/share/mariadb/ -mindepth 1 -type d ! -name 'charsets' ! -name 'english' -print0 | xargs -0 rm -rf \
-  # We need to allow anyone connect as root and need to do this while building the container
-  # since we can't modify this file at a later stage.
-  && sed -i -e 's/127.0.0.1/%/' /usr/share/mariadb/mysql_system_tables_data.sql \
-  && mkdir /run/mysqld \
-  && chown mysql:mysql /etc/my.cnf.d/ /run/mysqld /usr/share/mariadb/mysql_system_tables_data.sql \
-  && for p in aria* myisam* mysqld_* innochecksum \
-              mysqlslap replace wsrep* msql2mysql sst_dump \
-              resolve_stack_dump mysqlbinlog myrocks_hotbackup test-connect-t \
-              $(cd /usr/bin; ls mysql_*| grep -v mysql_install_db); \
-              do eval rm /usr/bin/${p}; done
+RUN apk add --no-cache mariadb=10.4.13-r0 && \
+  /bin/sh /clean.sh && \
+  touch /usr/share/mariadb/mysql_test_db.sql && \
+  sed -i -e 's/127.0.0.1/%/' /usr/share/mariadb/mysql_system_tables_data.sql && \
+  mkdir /run/mysqld && \
+  chown mysql:mysql /etc/my.cnf.d/ /run/mysqld /usr/share/mariadb/mysql_system_tables_data.sql
 
 # This is not super helpful; mysqld might be running but not accepting connections.
 # Since we have no clients, we can't really connect to it and check.

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -euo pipefail
+
+TO_KEEP=$(echo "
+  usr/bin/mysql$
+  usr/bin/mysqld$
+  usr/bin/mariadb$
+  usr/bin/getconf$
+  usr/bin/getent$
+  usr/bin/resolveip$
+  usr/bin/my_print_defaults$
+  usr/bin/mysql_install_db$
+  usr/share/mariadb/charsets
+  usr/share/mariadb/english
+  usr/share/mariadb/mysql_system_tables.sql$
+  usr/share/mariadb/mysql_performance_tables.sql$
+  usr/share/mariadb/mysql_system_tables_data.sql$
+  usr/share/mariadb/maria_add_gis_sp_bootstrap.sql$
+  usr/share/mariadb/fill_help_tables.sql$" |
+  tr -d " \t\n\r" | sed -e 's/usr/|usr/g' -e 's/^.//')
+
+INSTALLED_FILES="$(apk info -q -L mariadb-client | tail -n +2)
+$(apk info -q -L mariadb-common | tail -n +2)
+$(apk info -q -L mariadb | tail -n +2)"
+
+for path in $(echo "${INSTALLED_FILES}" | grep -v -E "${TO_KEEP}"); do
+  eval rm -rf "${path}"
+done


### PR DESCRIPTION
Significant changes to how we build (clean) the final image; we keep a whitelist instead of selectively removing things. This is moved into a separate script to keep error handling cleaner.

Finally, add [`hadolint`](https://github.com/hadolint/hadolint/) to verify that our Dockerfile is in shape.

The resulting image shrank by about 10%

| Repository | Tag | Image ID | Created | Size |
|:--|:--|:--|:--|:--|
| jbergstroem/mariadb-alpine | `latest` | `b8ebaf0bb7ac` | 10 minutes ago | 38.5MB |
| jbergstroem/mariadb-alpine | `f7e985e` | `7f924e8b227c` | 9 hours ago | 42.2MB |

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/7
Closes: https://github.com/jbergstroem/mariadb-alpine/pull/9