### PR TITLE
test: check starting InnoDB without a volume

### DIFF
--- a/test/02-innodb.bats
+++ b/test/02-innodb.bats
@@ -11,3 +11,12 @@ load test_helper
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }
+
+@test "start a server without a dedicated volume (issue #1)" {
+  local name="innodb-issue-1"
+  docker run -d --rm --name "${TEST_PREFIX}-${name}" "${IMAGE}":"${VERSION}"
+  sleep 5
+  run client_query "${name}" "-e 'select 1;'"
+  [[ "$status" -eq 0 ]]
+  decommission "${name}"
+}


### PR DESCRIPTION
Previous versions of MariaDB broke in certain scenarios when using docker, aufs or other mounted drives with Mariadb `10.2.x` and likely also some versions of `10.3.x`.

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/1