### PR TITLE
my.cnf: shrink some default memory settings

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -1,4 +1,6 @@
 [mariadb]
 innodb_buffer_pool_size = 10M
+innodb_log_buffer_size = 512K # default / 2
 innodb_log_file_size = 8M
 lower_case_table_names = 1
+key_buffer_size = 4194304 # default / 2


### PR DESCRIPTION
Apply moderate constraint to some of the biggest memory allocations. If you care about performance, you would want to mount your own `my.cnf` instead of using the default anyway.

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/18