### PR TITLE
docker: replace `resolveip` with polyfill

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
 !run.sh
 !clean.sh
+!resolveip.sh
 !my.cnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,20 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
       org.opencontainers.image.schema-version="1.0.0-rc.1" \
       org.opencontainers.image.license="MIT"
 
-COPY run.sh /run.sh
 COPY clean.sh /clean.sh
-COPY my.cnf /tmp/
 
 RUN apk add --no-cache mariadb=10.4.13-r0 && \
   /bin/sh /clean.sh && \
+  # removed in cleaning
   touch /usr/share/mariadb/mysql_test_db.sql && \
+  # allow anyone to connect by default
   sed -i -e 's/127.0.0.1/%/' /usr/share/mariadb/mysql_system_tables_data.sql && \
   mkdir /run/mysqld && \
   chown mysql:mysql /etc/my.cnf.d/ /run/mysqld /usr/share/mariadb/mysql_system_tables_data.sql
+
+COPY resolveip.sh /usr/bin/resolveip
+COPY run.sh /run.sh
+COPY my.cnf /tmp/my.cnf
 
 # This is not super helpful; mysqld might be running but not accepting connections.
 # Since we have no clients, we can't really connect to it and check.

--- a/clean.sh
+++ b/clean.sh
@@ -7,7 +7,6 @@ TO_KEEP=$(echo "
   usr/bin/mariadb$
   usr/bin/getconf$
   usr/bin/getent$
-  usr/bin/resolveip$
   usr/bin/my_print_defaults$
   usr/bin/mysql_install_db$
   usr/share/mariadb/charsets

--- a/resolveip.sh
+++ b/resolveip.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -euo pipefail
+
+[ -z "${1:-}" ] && exit 1
+
+if echo "${1}" | grep -q "^[0-9]"; then
+  echo "Host name of ${1} is localhost, localhost"
+else
+  echo "IP address of ${1} is 127.0.0.1"
+fi


### PR DESCRIPTION
This shaves off additional size (~9%) from the image. Also, reorder a few things in `Dockerfile` to use caching more efficiently in a developer environment.

| Repository | Commit | Size |
|:--|:--|:--|
| jbergstroem/mariadb-alpine | 13521c1 | 35.1MB |
| jbergstroem/mariadb-alpine | a7a9cdb | 38.5MB |
