### PR TITLE
docker: support a custom config file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
           wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJ
           sudo cp "shellcheck-${scversion}/shellcheck" /usr/local/bin/
       - name: test bats suite
-        run: shellcheck -s bash test/*
+        run: shellcheck -s bash test/*.bats test/*.bash
       - name: test utility scripts
         run: shellcheck -s dash *.sh bin/*
   hadolint:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ are unset unless provided.
    disk allocation size. If you mount a persistent volume
    this setting will be remembered.
 
+### Adding your custom config
+
+You can add your custom `my.cnf` with various settings (be it for production or tuning InnoDB).
+Note: this will bypass `SKIP_INNODB` since it is injected into the default config on launch.
+
+```console
+$ docker run -it --rm --name=db \
+         -v $(PWD)/config/my.cnf:/etc/my.cnf.d/my.cnf
+         jbergstroem/mariadb-alpine
+```
+
 ### Adding custom sql on init
 
 When a database is empty, the `mysql_install_db` script will be invoked. As part of this, you can pass custom input via the commonly used `/docker-entrypoint-initdb.d` convention. This will not be run when an existing database is found.
@@ -127,7 +138,7 @@ instructions in [their repository][4]. To test:
 ```console
 $ bin/build-image.sh
 <snip>
-$ bats test
+$ VERSION=c363434 bats test
  ✓ should output mysqld version
  ✓ start a default server with InnoDB and no password
  ✓ start a server without a dedicated volume (issue #1)
@@ -136,11 +147,12 @@ $ bats test
  ✓ start a server with a custom database
  ✓ start a server with a custom database, user and password
  ✓ verfiy that binary logging is turned off
+ ✓ should allow a user to pass a custom config
  ✓ should import a .sql file and execute it
  ✓ should import a compressed file and execute it
  ✓ should execute an imported shell script
 
-11 tests, 0 failures
+12 tests, 0 failures
 ```
 
 ## Benchmarks

--- a/test/03-configuration.bats
+++ b/test/03-configuration.bats
@@ -48,3 +48,13 @@ load test_helper
   [[ "$status" -eq 0 ]]
   decommission "${name}"
 }
+
+@test "should allow a user to pass a custom config" {
+  local name="custom-config"
+  create ${name} "-e SKIP_INNODB=1 -v ${BATS_TEST_DIRNAME}/fixtures/user-my.cnf:/etc/my.cnf.d/my.cnf"
+  sleep 2
+  run client_query "${name}" "-s -N -e 'select @@key_buffer_size;'"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "1048576" ]]
+  decommission "${name}"
+}

--- a/test/fixtures/user-my.cnf
+++ b/test/fixtures/user-my.cnf
@@ -1,0 +1,5 @@
+[mariadb]
+skip_innodb = yes
+default_storage_engine = MyISAM
+default_tmp_storage_engine = MyISAM
+key_buffer_size = 1048576


### PR DESCRIPTION
You can now provide a custom config file by mounting it into `/etc/my.cnf.d/`.

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/34