### PR TITLE
ci: lint repository with `prettier`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: brpaz/hadolint-action@master
+  prettier:
+    runs-on: ubuntu-latest
+    name: prettier
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - name: install prettier
+        run: npm install -g prettier
+      - name: run prettier
+        run: prettier -c .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           DOCKER_BUILDKIT: 1
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: "12.x"
       - name: install
         run: npm install -g bats
       - name: run suite

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ $ docker run -it --rm --name=db \
 You can override default behavior by passing environment variables. All flags
 are unset unless provided.
 
--  **MYSQL_DATABASE**: creates a database as provided by input
--  **MYSQL_USER**: creates a user with owner permissions over said database
--  **MYSQL_PASSWORD**: changes password of the provided user (not root)
--  **MYSQL_ROOT_PASSWORD**: sets a root password
--  **SKIP_INNODB**: skip using InnoDB which shaves off both time and
-   disk allocation size. If you mount a persistent volume
-   this setting will be remembered.
+- **MYSQL_DATABASE**: creates a database as provided by input
+- **MYSQL_USER**: creates a user with owner permissions over said database
+- **MYSQL_PASSWORD**: changes password of the provided user (not root)
+- **MYSQL_ROOT_PASSWORD**: sets a root password
+- **SKIP_INNODB**: skip using InnoDB which shaves off both time and
+  disk allocation size. If you mount a persistent volume
+  this setting will be remembered.
 
 ### Adding your custom config
 
@@ -160,13 +160,13 @@ $ VERSION=c363434 bats test
 The main goal of this project is to save disk space and startup time. At the moment,
 we only track disk space:
 
- | Name | Version | Size |
- | ---- | ------- | ---- |
- | mysql  | <img src="https://img.shields.io/docker/v/_/mysql/5.7?color=666&label=%22%22"> | <img src="https://img.shields.io/docker/image-size/_/mysql/5.7?color=666&label=%22%22"> |
- | mariadb | <img src="https://img.shields.io/docker/v/_/mariadb/10.4?color=666&label=%22%22"> | <img src="https://img.shields.io/docker/image-size/_/mariadb/10.4?color=666&label=%22%22"> |
- | bitnami/mariadb | <img src="https://img.shields.io/docker/v/bitnami/mariadb/10.4?color=666&label=%22%22"> | <img src="https://img.shields.io/docker/image-size/bitnami/mariadb/10.4?color=666&label=%22%22"> |
- | yobasystems/alpine-mariadb | <img src="https://img.shields.io/docker/v/yobasystems/alpine-mariadb?color=666&label=%22%22"> | <img src="https://img.shields.io/docker/image-size/yobasystems/alpine-mariadb?color=666&label=%22%22"> |
- | jbergstroem/mariadb-alpine | <img src="https://img.shields.io/docker/v/jbergstroem/mariadb-alpine?color=666&&sort=semver&label="> | <img src="https://img.shields.io/docker/image-size/jbergstroem/mariadb-alpine?color=666&sort=semver&label="> |
+| Name                       | Version                                                                                              | Size                                                                                                         |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| mysql                      | <img src="https://img.shields.io/docker/v/_/mysql/5.7?color=666&label=%22%22">                       | <img src="https://img.shields.io/docker/image-size/_/mysql/5.7?color=666&label=%22%22">                      |
+| mariadb                    | <img src="https://img.shields.io/docker/v/_/mariadb/10.4?color=666&label=%22%22">                    | <img src="https://img.shields.io/docker/image-size/_/mariadb/10.4?color=666&label=%22%22">                   |
+| bitnami/mariadb            | <img src="https://img.shields.io/docker/v/bitnami/mariadb/10.4?color=666&label=%22%22">              | <img src="https://img.shields.io/docker/image-size/bitnami/mariadb/10.4?color=666&label=%22%22">             |
+| yobasystems/alpine-mariadb | <img src="https://img.shields.io/docker/v/yobasystems/alpine-mariadb?color=666&label=%22%22">        | <img src="https://img.shields.io/docker/image-size/yobasystems/alpine-mariadb?color=666&label=%22%22">       |
+| jbergstroem/mariadb-alpine | <img src="https://img.shields.io/docker/v/jbergstroem/mariadb-alpine?color=666&&sort=semver&label="> | <img src="https://img.shields.io/docker/image-size/jbergstroem/mariadb-alpine?color=666&sort=semver&label="> |
 
 [1]: https://mariadb.org
 [2]: https://alpinelinux.org


### PR DESCRIPTION
Prettier is a nice way to argue less about semantics. The idea is to pave the way for a `doc` folder, but it also caught irregularities in YAML files.

Refs: https://github.com/jbergstroem/mariadb-alpine/issues/39