### PR TITLE
Support `MYSQL_CHARSET` and `MYSQL_COLLATION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ $ docker run -it --rm --name=db \
 You can override default behavior by passing environment variables. All flags
 are unset unless provided.
 
-- **MYSQL_DATABASE**: creates a database as provided by input
-- **MYSQL_USER**: creates a user with owner permissions over said database
-- **MYSQL_PASSWORD**: changes password of the provided user (not root)
-- **MYSQL_ROOT_PASSWORD**: sets a root password
+- **MYSQL_DATABASE**: create a database as provided by input
+- **MYSQL_CHARSET**: set charset for said database
+- **MYSQL_COLLATION**: set default collation for said database
+- **MYSQL_USER**: create a user with owner permissions over said database
+- **MYSQL_PASSWORD**: change password of the provided user (not root)
+- **MYSQL_ROOT_PASSWORD**: set a root password
 - **SKIP_INNODB**: skip using InnoDB which shaves off both time and
   disk allocation size. If you mount a persistent volume
   this setting will be remembered.

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,11 @@ if [ -z "$(ls -A /var/lib/mysql/ 2> /dev/null)" ]; then
   INSTALL_OPTS="${INSTALL_OPTS} --datadir=/var/lib/mysql"
   eval /usr/bin/mysql_install_db "${INSTALL_OPTS}"
 
-  [ -n "${MYSQL_DATABASE}" ] && echo "create database if not exists \`${MYSQL_DATABASE}\` character set utf8 collate utf8_general_ci; " >> /tmp/init
+  if [ -n "${MYSQL_DATABASE}" ]; then
+    [ -n "${MYSQL_CHARSET}" ] || MYSQL_CHARSET="utf8"
+    [ -n "${MYSQL_COLLATION}" ] && MYSQL_COLLATION="collate '${MYSQL_COLLATION}'"
+    echo "create database if not exists \`${MYSQL_DATABASE}\` character set '${MYSQL_CHARSET}' ${MYSQL_COLLATION}; " >> /tmp/init
+  fi
   if [ -n "${MYSQL_USER}" ] && [ "${MYSQL_DATABASE}" ]; then
     echo "grant all on \`${MYSQL_DATABASE}\`.* to '${MYSQL_USER}'@'%' identified by '${MYSQL_PASSWORD}'; " >> /tmp/init
   fi 

--- a/test/03-configuration.bats
+++ b/test/03-configuration.bats
@@ -40,6 +40,26 @@ load test_helper
   decommission "${name}"
 }
 
+@test "should allow to customize the database charset" {
+  local name="custom-charset"
+  create ${name} "-e SKIP_INNODB=1 -e MYSQL_DATABASE=bar -e MYSQL_CHARSET=hebrew"
+  sleep 2
+  run client_query "${name}" "-s -N --database=bar -e 'select @@character_set_database;'"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "hebrew" ]]
+  decommission "${name}"
+}
+
+@test "should allow to customize the database collation" {
+  local name="custom-collation"
+  create ${name} "-e SKIP_INNODB=1 -e MYSQL_DATABASE=bar -e MYSQL_CHARSET=utf8mb4 -e MYSQL_COLLATION=utf8mb4_bin"
+  sleep 2
+  run client_query "${name}" "-s -N --database=bar -e 'select @@collation_database;'"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "utf8mb4_bin" ]]
+  decommission "${name}"
+}
+
 @test "verfiy that binary logging is turned off" {
   local name="no-log-bin"
   create ${name} "-e SKIP_INNODB=1"


### PR DESCRIPTION
When creating a database you can pass these environment variables to control what charset and potentially collation you'd like to use. If you don't provide a charset, `utf8` will be used.

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/33