### PR TITLE
Parallel tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,10 @@ jobs:
         env:
           VERSION: ${{ steps.assign.outputs.version }}
           DOCKER_BUILDKIT: 1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
       - name: install
-        run: npm install -g bats
+        run: |
+          curl -L https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar zx --strip=1 -C /tmp/ &&
+          sudo /tmp/install.sh /usr/local
       - name: run suite
         run: sh/run-tests.bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,6 @@ jobs:
       - name: install
         run: npm install -g bats
       - name: run suite
-        run: sh/build-image.sh
+        run: sh/run-tests.bash
         env:
           VERSION: ${{ steps.assign.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY my.cnf /tmp/my.cnf
 # Since we have no clients, we can't really connect to it and check.
 #
 # Below is in my opinion better than no health check.
-HEALTHCHECK --start-period=3s CMD pgrep mysqld
+HEALTHCHECK --start-period=5s CMD pgrep mysqld
 
 VOLUME ["/var/lib/mysql"]
 ENTRYPOINT ["/run.sh"]

--- a/sh/run-tests.bash
+++ b/sh/run-tests.bash
@@ -25,8 +25,7 @@ clean() {
 
 # clean previous runs
 clean
-# pass all xargs since we might wanna do `-j 3`
-bats test/*.bats "$@"
+bats test/*.bats -j "$(nproc)"
 clean
 # remove temp folders. make sure this cannot be destructive if for instance
 # ${MY_TMPDIR} would be "/"

--- a/sh/run-tests.bash
+++ b/sh/run-tests.bash
@@ -5,12 +5,7 @@ export IMAGE=${IMAGE:-jbergstroem/mariadb-alpine}
 export VERSION=${VERSION:-latest}
 export TEST_PREFIX="mariadb-alpine-bats-test"
 
-# From https://github.com/bats-core/bats-core/blob/master/lib/bats-core/preprocessing.bash#L3
-if [ -z "$TMPDIR" ]; then
-	DEFAULT_TMPDIR='/tmp'
-else
-	DEFAULT_TMPDIR="${TMPDIR%/}"
-fi
+DEFAULT_TMPDIR=${TMPDIR:-/tmp}
 
 MY_TMPDIR=$(mktemp -d "${DEFAULT_TMPDIR}"/"${TEST_PREFIX}".XXXXXX)
 export MY_TMPDIR

--- a/sh/run-tests.bash
+++ b/sh/run-tests.bash
@@ -36,4 +36,4 @@ clean
 # remove temp folders. make sure this cannot be destructive if for instance
 # ${MY_TMPDIR} would be "/"
 SUFFIX=$(basename "${MY_TMPDIR}")
-find "${DEFAULT_TMPDIR}" -type d -maxdepth 1 -name "${SUFFIX}" -delete
+find "${DEFAULT_TMPDIR}" -type d -maxdepth 1 -name "${SUFFIX}" -delete > /dev/null 2>&1

--- a/test/02-innodb.bats
+++ b/test/02-innodb.bats
@@ -6,7 +6,7 @@ load test_helper
 @test "start a default server with InnoDB and no password" {
   local name="default-startup"
   create ${name} ""
-  sleep 5
+  wait_until_up "${name}"
   run client_query "${name}" "-e 'SHOW ENGINE INNODB STATUS;'"
   [[ "$status" -eq 0 ]]
   stop "${name}"
@@ -15,7 +15,7 @@ load test_helper
 @test "start a server without a dedicated volume (issue #1)" {
   local name="innodb-issue-1"
   docker run -d --rm --name "${TEST_PREFIX}-${name}" "${IMAGE}":"${VERSION}"
-  sleep 5
+  wait_until_up "${name}"
   run client_query "${name}" "-e 'select 1;'"
   [[ "$status" -eq 0 ]]
   stop "${name}"

--- a/test/03-configuration.bats
+++ b/test/03-configuration.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "start a server without InnoDB" {
   local name="skip-innodb-startup"
   create ${name} "-e SKIP_INNODB=1"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "-e 'SHOW ENGINE INNODB STATUS;'"
   [[ "$status" -eq 1 ]]
   run client_query "${name}" "-e 'select 1;'"
@@ -16,7 +16,7 @@ load test_helper
 @test "start a server with a custom root password" {
   local name="root-password"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_ROOT_PASSWORD=secretsauce"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}"  "--password=secretsauce -e 'select 1;'"
   [[ "$status" -eq 0 ]]
   stop "${name}"
@@ -25,7 +25,7 @@ load test_helper
 @test "start a server with a custom database" {
   local name="custom-db"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_DATABASE=bar"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "--database=bar -e 'select 1;'"
   [[ "$status" -eq 0 ]]
   stop "${name}"
@@ -34,7 +34,7 @@ load test_helper
 @test "start a server with a custom database, user and password" {
   local name="custom-user-password"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_USER=foo -e MYSQL_DATABASE=bar -e MYSQL_PASSWORD=baz"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "--user=foo --database=bar --password=baz -e 'select 1;'"
   [[ "$status" -eq 0 ]]
   stop "${name}"
@@ -43,7 +43,7 @@ load test_helper
 @test "should allow to customize the database charset" {
   local name="custom-charset"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_DATABASE=bar -e MYSQL_CHARSET=hebrew"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "-s -N --database=bar -e 'select @@character_set_database;'"
   [[ "$status" -eq 0 ]]
   [[ "$output" == "hebrew" ]]
@@ -53,7 +53,7 @@ load test_helper
 @test "should allow to customize the database collation" {
   local name="custom-collation"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_DATABASE=bar -e MYSQL_CHARSET=utf8mb4 -e MYSQL_COLLATION=utf8mb4_bin"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "-s -N --database=bar -e 'select @@collation_database;'"
   [[ "$status" -eq 0 ]]
   [[ "$output" == "utf8mb4_bin" ]]
@@ -63,7 +63,7 @@ load test_helper
 @test "verfiy that binary logging is turned off" {
   local name="no-log-bin"
   create ${name} "-e SKIP_INNODB=1"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "-s -N -e 'select @@log_bin;'"
   [[ "$status" -eq 0 ]]
   [[ "$output" == "0" ]]
@@ -73,7 +73,7 @@ load test_helper
 @test "should allow a user to pass a custom config" {
   local name="custom-config"
   create ${name} "-e SKIP_INNODB=1 -v ${BATS_TEST_DIRNAME}/fixtures/user-my.cnf:/etc/my.cnf.d/my.cnf"
-  sleep 2
+  wait_until_up "${name}"
   run client_query "${name}" "-s -N -e 'select @@key_buffer_size;'"
   [[ "$status" -eq 0 ]]
   [[ "$output" == "1048576" ]]

--- a/test/04-import.bats
+++ b/test/04-import.bats
@@ -11,7 +11,7 @@ load test_helper
   mkdir -p "${tmpdir}"
   echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
-  sleep 5
+  wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"
   [[ "${status}" -eq 0 ]]
   rm -rf "${tmpdir}"
@@ -28,7 +28,7 @@ load test_helper
   # and for some reason the temp directory wasn't properly cleaned.
   gzip  "${tmpdir}/mydatabase.sql"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
-  sleep 5
+  wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"
   [[ "${status}" -eq 0 ]]
   rm -rf "${tmpdir}"
@@ -41,7 +41,7 @@ load test_helper
   mkdir -p "${tmpdir}"
   echo "mysql -e \"create database mydatabase;\"" > "${tmpdir}/custom.sh"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
-  sleep 5
+  wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"
   [[ "${status}" -eq 0 ]]
   rm -rf "${tmpdir}"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,6 +9,14 @@ create() {
   run eval docker run -d --rm --name "${TEST_PREFIX}-${1}" -v "${TEST_PREFIX}-${1}":/var/lib/mysql "${2}" "${IMAGE}":"${VERSION}"
 }
 
+wait_until_up() {
+  # $1: container name
+  until docker logs --tail 1 "${TEST_PREFIX}-${1}" 2>&1 | grep "Version:"
+  do
+    sleep 0.25
+  done
+}
+
 client_query() {
   # $1: name of container
   # $2: query to run

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -13,7 +13,7 @@ wait_until_up() {
   # $1: container name
   until docker logs --tail 1 "${TEST_PREFIX}-${1}" 2>&1 | grep "Version:"
   do
-    sleep 0.25
+    sleep 0.2
   done
 }
 


### PR DESCRIPTION
Introduce running tests in parallel and improve running time while avoiding the default sleep period by tailing logs for ready state.

There is a slight discrepancy between `docker logs` and network being ready, but its small enough in our case to not really matter.

Edit: this cuts about 60% running time on my laptop with 4 cores.