### PR TITLE
fix: rename dependabot config attribute

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    default_labels:
+    labels:
       - "type: dependencies"
     schedule:
       interval: "daily"


### PR DESCRIPTION
In b3c35bc I incorrectly introduced an attribute that was referring to an older version of dependabot.