### PR TITLE
add docker-compose template. add `Port` config. add extra-options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,3 +62,9 @@ HEALTHCHECK --start-period=5s CMD pgrep mysqld
 VOLUME ["/var/lib/mysql"]
 ENTRYPOINT ["/run.sh"]
 EXPOSE 3306
+
+
+# docker login
+# docker build ./ -f Dockerfile -t mysql:1
+# docker tag mysql:1 yorkane/alpine-mariadb:10.4.22
+# docker push yorkane/alpine-mariadb:10.4.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN \
     tr -d " \t\n\r" | sed -e 's/usr/|usr/g' -e 's/^.//') && \
   INSTALLED=$(apk info -q -L mariadb-common mariadb linux-pam | grep "\S") && \
   for path in $(echo "${INSTALLED}" | grep -v -E "${TO_KEEP}"); do \
+    echo "remove ${path}";\
     eval rm -rf "${path}"; \
   done && \
   touch /usr/share/mariadb/mysql_test_db.sql && \
@@ -43,7 +44,8 @@ RUN \
   # allow anyone to connect by default
   sed -ie 's/127.0.0.1/%/' /usr/share/mariadb/mysql_system_tables_data.sql && \
   mkdir /run/mysqld && \
-  chown mysql:mysql /etc/my.cnf.d/ /run/mysqld /usr/share/mariadb/mysql_system_tables_data.sql
+  chown mysql:mysql /etc/my.cnf.d/ /run/mysqld /usr/share/mariadb/mysql_system_tables_data.sql && \
+  rm /etc/my.cnf.d/* -rf
 
 # The one installed by MariaDB was removed in the clean step above due to its large footprint
 COPY sh/resolveip.sh /usr/bin/resolveip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  mysql:
+    image: jbergstroem/mariadb-alpine
+    container_name: mysql
+    ports:
+      - "3306:3306/tcp"
+    volumes:
+      - ${DATA_ROOT:-.}/db/data:/var/lib/mysql # where database and logs preserve
+      - ${DATA_ROOT:-.}/db/init:/docker-entrypoint-initdb.d # All xxx.sql, xxx.sql.gz will load into MY_DB. All `xxx.sh` will be executed
+    environment:
+      - MYSQL_DATABASE=${MY_DB:-mtest}
+      - MYSQL_CHARSET=${MY_DB_CHARSET:-utf8mb4}
+      - MYSQL_COLLATION=${MY_DB_COLLATION:-utf8mb4_general_ci}
+      - MYSQL_USER=${MY_DB_USER:-mtest}
+      - MYSQL_PASSWORD=${MY_DB_PASSWORD:-mtest} #
+      - MYSQL_ROOT_PASSWORD=${MY_ROOT_PASSWORD:-root} # set the root password
+      - MYSQL_PORT=3306
+# extra options for mysqld
+#https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html
+# Verify by `SHOW GLOBAL VARIABLES LIKE 'innodb_flush_log%';`
+      - MYSQL_EXT_OPTS= --innodb-flush-log-at-trx-commit=0 --innodb-flush-log-at-timeout=0

--- a/sh/run.sh
+++ b/sh/run.sh
@@ -98,7 +98,7 @@ fi
 # make sure directory permissions are correct before starting up
 # https://github.com/jbergstroem/mariadb-alpine/issues/54
 chown -R mysql:mysql /var/lib/mysql
-
+chmod 644 /etc/my.cnf.d/my.cnf
 printenv
 echo "/usr/bin/mysqld ${MYSQLD_OPTS}"
 eval exec /usr/bin/mysqld "${MYSQLD_OPTS}"

--- a/sh/run.sh
+++ b/sh/run.sh
@@ -14,7 +14,7 @@ if [ -z "$(ls -A /etc/my.cnf.d/* 2> /dev/null)" ]; then
         -e '/^innodb/d' /etc/my.cnf.d/my.cnf
 fi
 
-MYSQLD_OPTS="--user=mysql"
+MYSQLD_OPTS="--user=mysql --port=${MYSQL_PORT} ${MYSQL_EXT_OPTS}"
 MYSQLD_OPTS="${MYSQLD_OPTS} --skip-name-resolve"
 MYSQLD_OPTS="${MYSQLD_OPTS} --skip-host-cache"
 MYSQLD_OPTS="${MYSQLD_OPTS} --skip-slave-start"
@@ -99,4 +99,6 @@ fi
 # https://github.com/jbergstroem/mariadb-alpine/issues/54
 chown -R mysql:mysql /var/lib/mysql
 
+printenv
+echo "/usr/bin/mysqld ${MYSQLD_OPTS}"
 eval exec /usr/bin/mysqld "${MYSQLD_OPTS}"


### PR DESCRIPTION
Fix my.cnf  mapping cause mysql start with `port:0` (introduced by mariadb-server.cnf)
Deletions information output
Draft template for docker-compose.yml
Make `Port` `mysqld-commandline-options` configurable


