### PR TITLE
refactor: use mariadb binaries instead of mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,11 @@ RUN \
   apk add --no-cache mariadb=10.6.4-r2 && \
   TO_KEEP=$(echo " \
     usr/bin/mariadbd$ \
-    usr/bin/mysqld$ \
     usr/bin/mariadb$ \
-    usr/bin/mysql$ \
     usr/bin/getconf$ \
     usr/bin/getent$ \
     usr/bin/my_print_defaults$ \
     usr/bin/mariadb-install-db$ \
-    usr/bin/mysql_install_db$ \
     usr/share/mariadb/charsets \
     usr/share/mariadb/english \
     usr/share/mariadb/mysql_system_tables.sql$ \

--- a/sh/run.sh
+++ b/sh/run.sh
@@ -34,7 +34,7 @@ if [ -z "$(ls -A /var/lib/mysql/ 2> /dev/null)" ]; then
   INSTALL_OPTS="${INSTALL_OPTS} --auth-root-authentication-method=normal"
   INSTALL_OPTS="${INSTALL_OPTS} --skip-test-db"
   INSTALL_OPTS="${INSTALL_OPTS} --datadir=/var/lib/mysql"
-  eval /usr/bin/mysql_install_db "${INSTALL_OPTS}"
+  eval /usr/bin/mariadb-install-db "${INSTALL_OPTS}"
 
   if [ -n "${MYSQL_DATABASE}" ]; then
     [ -n "${MYSQL_CHARSET}" ] || MYSQL_CHARSET="utf8"
@@ -60,11 +60,11 @@ if [ -z "$(ls -A /var/lib/mysql/ 2> /dev/null)" ]; then
     apk add -q --no-cache mariadb-client
 
     SOCKET="/run/mysqld/mysqld.sock"
-    MYSQL_CMD="mysql"
+    MYSQL_CMD="mariadb"
 
     # Start a mysqld we will use to pass init stuff to. Can't use the same options
     # as a standard instance; pass them manually.
-    mysqld --user=mysql --silent-startup --skip-networking --socket=${SOCKET} > /dev/null 2>&1 &
+    mariadbd --user=mysql --silent-startup --skip-networking --socket=${SOCKET} > /dev/null 2>&1 &
     PID="$!"
 
     # perhaps trap this to avoid issues on slow systems?
@@ -99,4 +99,4 @@ fi
 # https://github.com/jbergstroem/mariadb-alpine/issues/54
 chown -R mysql:mysql /var/lib/mysql
 
-eval exec /usr/bin/mysqld "${MYSQLD_OPTS}"
+eval exec /usr/bin/mariadbd "${MYSQLD_OPTS}"

--- a/test/01-sanity_check.bats
+++ b/test/01-sanity_check.bats
@@ -2,14 +2,14 @@
 
 load test_helper
 
-@test "should output mysqld version" {
-  run docker run --rm --entrypoint mysqld "${IMAGE}":"${VERSION}" --version
+@test "should output mariadbd version" {
+  run docker run --rm --entrypoint mariadbd "${IMAGE}":"${VERSION}" --version
   [[ "${status}" -eq 0 ]]
   local grepopt
   grepopt="-E"
   if [[ $(uname -s) == "Linux" ]]; then
     grepopt="-P"
   fi
-  run grep "${grepopt}" '^mysqld\s+Ver\s+\d+\.\d+\.\d+-MariaDB*' <<< "${output}"
+  run grep "${grepopt}" '^mariadbd\s+Ver\s+\d+\.\d+\.\d+-MariaDB*' <<< "${output}"
   [[ "${status}" -eq 0 ]]
 }

--- a/test/04-import.bats
+++ b/test/04-import.bats
@@ -39,7 +39,7 @@ load test_helper
   local name="sh-import"
   local tmpdir="${MY_TMPDIR}/${name}"
   mkdir -p "${tmpdir}"
-  echo "mysql -e \"create database mydatabase;\"" > "${tmpdir}/custom.sh"
+  echo "mariadb -e \"create database mydatabase;\"" > "${tmpdir}/custom.sh"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"

--- a/test/fixtures/user-my.cnf
+++ b/test/fixtures/user-my.cnf
@@ -1,5 +1,6 @@
 [mariadb]
 skip_innodb = yes
-default_storage_engine = MyISAM
-default_tmp_storage_engine = MyISAM
+default_storage_engine = Aria
+default_tmp_storage_engine = Aria
 key_buffer_size = 1048576
+aria_log_file_size = 8M


### PR DESCRIPTION
- use `mariadbd` binaries instead of `mysqld` symlinks
- delete symlinks for mysql and mysqld