### PR TITLE
chore: remove original ca certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ SHELL ["/bin/ash", "-euo", "pipefail", "-c"]
 RUN \
   apk add --no-cache mariadb=10.6.4-r2 && \
   TO_KEEP=$(echo " \
+    etc/ssl/certs/ca-certificates.crt$ \
     usr/bin/mariadbd$ \
     usr/bin/mariadb$ \
     usr/bin/getconf$ \
@@ -34,7 +35,7 @@ RUN \
     usr/share/mariadb/mysql_sys_schema.sql$ \
     usr/share/mariadb/fill_help_tables.sql$" | \
     tr -d " \t\n\r" | sed -e 's/usr/|usr/g' -e 's/^.//') && \
-  INSTALLED=$(apk info -q -L mariadb-common mariadb linux-pam | grep "\S") && \
+  INSTALLED=$(apk info -q -L mariadb-common mariadb linux-pam ca-certificates | grep "\S") && \
   for path in $(echo "${INSTALLED}" | grep -v -E "${TO_KEEP}"); do \
     eval rm -rf "${path}"; \
   done && \

--- a/README.md
+++ b/README.md
@@ -154,21 +154,24 @@ instructions in [their repository][4]. To test:
 ```console
 $ sh/build-image.sh
 <snip>
-$ VERSION=c363434 sh/run-tests.bash
- ✓ should output mysqld version
+$ VERSION=e558404 sh/run-tests.bash
+ ✓ should output mariadbd version
  ✓ start a default server with InnoDB and no password
  ✓ start a server without a dedicated volume (issue #1)
  ✓ start a server without InnoDB
+ ✓ default to Aria when InnoDB is turned off
  ✓ start a server with a custom root password
  ✓ start a server with a custom database
  ✓ start a server with a custom database, user and password
+ ✓ should allow to customize the database charset
+ ✓ should allow to customize the database collation
  ✓ verify that binary logging is turned off
  ✓ should allow a user to pass a custom config
  ✓ should import a .sql file and execute it
  ✓ should import a compressed file and execute it
  ✓ should execute an imported shell script
 
-12 tests, 0 failures
+15 tests, 0 failures
 ```
 
 ## Benchmarks


### PR DESCRIPTION
`ca-certificates` bundles certificates into `/etc/ssl/certs/ca-certificates.crt`
so there's no need for the originals to stay around.

Shaves about `300kb` from image size