### PR TITLE
feat: shin `my_print_defaults`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 !sh/run.sh
 !sh/clean.sh
 !sh/resolveip.sh
+!sh/my_print_defaults.sh
 !my.cnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,16 @@ LABEL org.opencontainers.image.created=$BUILD_DATE \
 
 SHELL ["/bin/ash", "-euo", "pipefail", "-c"]
 
+ARG VERSION=10.6.9-r0
+
 RUN \
-  apk add --no-cache mariadb=10.6.9-r0 && \
+  apk add --no-cache mariadb=${VERSION} && \
   TO_KEEP=$(echo " \
     etc/ssl/certs/ca-certificates.crt$ \
     usr/bin/mariadbd$ \
     usr/bin/mariadb$ \
     usr/bin/getconf$ \
     usr/bin/getent$ \
-    usr/bin/my_print_defaults$ \
     usr/bin/mariadb-install-db$ \
     usr/share/mariadb/charsets \
     usr/share/mariadb/english \
@@ -47,8 +48,10 @@ RUN \
   mkdir /run/mysqld && \
   chown mysql:mysql /etc/my.cnf.d/ /run/mysqld /usr/share/mariadb/mysql_system_tables_data.sql
 
-# The one installed by MariaDB was removed in the clean step above due to its large footprint
+# The ones installed by MariaDB was removed in the clean step above due to its large footprint
+# my_print_defaults should cover 95% of cases since it doesn't properly do recursion
 COPY sh/resolveip.sh /usr/bin/resolveip
+COPY sh/my_print_defaults.sh /usr/bin/my_print_defaults
 COPY sh/run.sh /run.sh
 # Used in run.sh as a default config
 COPY my.cnf /tmp/my.cnf

--- a/sh/my_print_defaults.sh
+++ b/sh/my_print_defaults.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# shellcheck shell=dash
+set -euo pipefail
+
+# Stack overflow'ed - should rewrite in awk or even shell for readability
+sed -n \
+  '/^[ \t]*\[mariadb\]/,/\[/s/^[ \t]*\([^#; \t][^ \t=]*\).*=[ \t]*\(.*\)/--\1=\2/p' \
+  /etc/my.cnf.d/* | sed 's:#.*$::g'


### PR DESCRIPTION
`my_print_defaults` traverses your configs and returns a commandline representation of options for certain sections; most importantly `mariadb`. This scripts accomplishes the same. It is not without risk, but should be harm free for most - if not everyone. Lets see.

Using `docker save | gzip` (docker uses higher compression settings):
| Version | Size (bytes) | Savings |
| - | - | - |
| 17c5fb6 (master) | 13,242,045 | |
| c01bc7c (this PR) | 12,432,490 | **7.1%** |