### PR TITLE
chore: specify parser for all shellscripts

### DIFF
--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -18,7 +18,5 @@ jobs:
         run: |
           wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJ
           sudo cp "shellcheck-${scversion}/shellcheck" /usr/local/bin/
-      - name: test bats suite
-        run: shellcheck -s bash test/*.bats test/*.bash sh/*.bash
-      - name: test utility scripts
-        run: shellcheck -s dash sh/*.sh
+      - name: test shell scripts
+        run: shellcheck test/*.bats test/*.bash sh/*.bash sh/*.sh

--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ $ VERSION=e558404 sh/run-tests.bash
 The main goal of this project is to save disk space and startup time. At the moment, only disk space is tracked.
 Check out the tool to generate this data [here][6].
 
-| image name | size | digest (version) |
-|:--|:--|:--|
-| linuxserver/mariadb | 83.6Mi | [9e01d531](https://hub.docker.com/layers/linuxserver/mariadb/latest/images/sha256:9e01d531a25d272309f6eb80da1b13cce5f80c17cc5c834cebc16a926dc12b88?context=explore) |
-| **jbergstroem/mariadb-alpine** | 12.3Mi | [b01ecfa7](https://hub.docker.com/layers/jbergstroem/mariadb-alpine/latest/images/sha256:b01ecfa73d8ec2374541065c37dc429f7ab3a5fb208196e7691c698c6a9d9037?context=explore) |
-| clearlinux/mariadb | 278.0Mi | [e7010077](https://hub.docker.com/layers/clearlinux/mariadb/latest/images/sha256:e7010077b93ec174b08d23bed943a746997f2a38263510361c7c94e9e0893462?context=explore) |
-| mariadb | 118.4Mi | [59ef1139](https://hub.docker.com/layers/library/mariadb/latest/images/sha256:59ef1139afa1ec26f98e316a8dbef657daf9f64f84e9378b190d1d7557ad2feb?context=explore) |
-| bitnami/mariadb | 109.0Mi | [e10d22f3](https://hub.docker.com/layers/bitnami/mariadb/latest/images/sha256:e10d22f3f3348335a21da21bea92c6471be708c34e9ab244d1444740b06e2f5a?context=explore) |
-| mysql | 150.0Mi | [147572c9](https://hub.docker.com/layers/library/mysql/latest/images/sha256:147572c972192417add6f1cf65ea33edfd44086e461a3381601b53e1662f5d15?context=explore) |
+| image name                     | size    | digest (version)                                                                                                                                                           |
+| :----------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| linuxserver/mariadb            | 83.6Mi  | [9e01d531](https://hub.docker.com/layers/linuxserver/mariadb/latest/images/sha256:9e01d531a25d272309f6eb80da1b13cce5f80c17cc5c834cebc16a926dc12b88?context=explore)        |
+| **jbergstroem/mariadb-alpine** | 12.3Mi  | [b01ecfa7](https://hub.docker.com/layers/jbergstroem/mariadb-alpine/latest/images/sha256:b01ecfa73d8ec2374541065c37dc429f7ab3a5fb208196e7691c698c6a9d9037?context=explore) |
+| clearlinux/mariadb             | 278.0Mi | [e7010077](https://hub.docker.com/layers/clearlinux/mariadb/latest/images/sha256:e7010077b93ec174b08d23bed943a746997f2a38263510361c7c94e9e0893462?context=explore)         |
+| mariadb                        | 118.4Mi | [59ef1139](https://hub.docker.com/layers/library/mariadb/latest/images/sha256:59ef1139afa1ec26f98e316a8dbef657daf9f64f84e9378b190d1d7557ad2feb?context=explore)            |
+| bitnami/mariadb                | 109.0Mi | [e10d22f3](https://hub.docker.com/layers/bitnami/mariadb/latest/images/sha256:e10d22f3f3348335a21da21bea92c6471be708c34e9ab244d1444740b06e2f5a?context=explore)            |
+| mysql                          | 150.0Mi | [147572c9](https://hub.docker.com/layers/library/mysql/latest/images/sha256:147572c972192417add6f1cf65ea33edfd44086e461a3381601b53e1662f5d15?context=explore)              |
 
 [1]: https://mariadb.org
 [2]: https://alpinelinux.org

--- a/sh/build-image.sh
+++ b/sh/build-image.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck shell=bash
 
 IMAGE=${IMAGE:-jbergstroem/mariadb-alpine}
 SHORT_SHA=$(git rev-parse --short HEAD)
@@ -6,6 +7,6 @@ DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 VERSION=${VERSION:-${SHORT_SHA}}
 
 docker image build \
-	--build-arg BUILD_DATE="${DATE}" \
-    --build-arg VCS_REF="${SHORT_SHA}" \
-    -t "${IMAGE}:${VERSION}" .
+  --build-arg BUILD_DATE="${DATE}" \
+  --build-arg VCS_REF="${SHORT_SHA}" \
+  -t "${IMAGE}:${VERSION}" .

--- a/sh/run-tests.bash
+++ b/sh/run-tests.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
 
 [[ -n "${DEBUG}" ]] && set -x
 set -euo pipefail
@@ -20,16 +21,16 @@ else
 fi
 
 # Check prerequisites before starting
-command -v docker  > /dev/null 2>&1
-docker inspect "${IMAGE}":"${VERSION}" > /dev/null 2>&1
+command -v docker >/dev/null 2>&1
+docker inspect "${IMAGE}":"${VERSION}" >/dev/null 2>&1
 
 clean() {
   local filter="" running="" volumes=""
   filter="-f name=${TEST_PREFIX}"
   running=$(docker ps -q "${filter}")
   volumes=$(docker volume ls -q "${filter}")
-  [ "${running}" == "" ] || echo "${running}" | xargs docker stop {} > /dev/null 2>&1
-  [ "${volumes}" == "" ] || echo "${volumes}" | xargs docker volume rm -f {} > /dev/null 2>&1
+  [ "${running}" == "" ] || echo "${running}" | xargs docker stop {} >/dev/null 2>&1
+  [ "${volumes}" == "" ] || echo "${volumes}" | xargs docker volume rm -f {} >/dev/null 2>&1
 }
 
 # clean previous runs
@@ -39,4 +40,4 @@ clean
 # remove temp folders. make sure this cannot be destructive if for instance
 # ${MY_TMPDIR} would be "/"
 SUFFIX=$(basename "${MY_TMPDIR}")
-find "${DEFAULT_TMPDIR}" -type d -maxdepth 1 -name "${SUFFIX}" -delete > /dev/null 2>&1
+find "${DEFAULT_TMPDIR}" -type d -maxdepth 1 -name "${SUFFIX}" -delete >/dev/null 2>&1

--- a/test/01-sanity_check.bats
+++ b/test/01-sanity_check.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck shell=bash
 
 load test_helper
 
@@ -10,6 +11,6 @@ load test_helper
   if [[ $(uname -s) == "Linux" ]]; then
     grepopt="-P"
   fi
-  run grep "${grepopt}" '^mariadbd\s+Ver\s+\d+\.\d+\.\d+-MariaDB*' <<< "${output}"
+  run grep "${grepopt}" '^mariadbd\s+Ver\s+\d+\.\d+\.\d+-MariaDB*' <<<"${output}"
   [[ "${status}" -eq 0 ]]
 }

--- a/test/02-innodb.bats
+++ b/test/02-innodb.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck shell=bash
 
 load test_helper
 

--- a/test/03-configuration.bats
+++ b/test/03-configuration.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck shell=bash
 
 load test_helper
 
@@ -27,7 +28,7 @@ load test_helper
   local name="root-password"
   create ${name} "-e SKIP_INNODB=1 -e MYSQL_ROOT_PASSWORD=secretsauce"
   wait_until_up "${name}"
-  run client_query "${name}"  "--password=secretsauce -e 'select 1;'"
+  run client_query "${name}" "--password=secretsauce -e 'select 1;'"
   [[ "$status" -eq 0 ]]
   stop "${name}"
 }

--- a/test/04-import.bats
+++ b/test/04-import.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck shell=bash
 
 load test_helper
 
@@ -9,7 +10,7 @@ load test_helper
   local name="sql-import"
   local tmpdir="${MY_TMPDIR}/${name}"
   mkdir -p "${tmpdir}"
-  echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
+  echo "create database mydatabase;" >"${tmpdir}/mydatabase.sql"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"
@@ -22,11 +23,11 @@ load test_helper
   local name="sql-import-gz"
   local tmpdir="${MY_TMPDIR}/${name}"
   mkdir -p "${tmpdir}"
-  echo "create database mydatabase;" > "${tmpdir}/mydatabase.sql"
+  echo "create database mydatabase;" >"${tmpdir}/mydatabase.sql"
   # if you seemingly get stuck here, it's because gzip is attempting to overwrite
   # the existing file. This means your previous run didn't execute successfully
   # and for some reason the temp directory wasn't properly cleaned.
-  gzip  "${tmpdir}/mydatabase.sql"
+  gzip "${tmpdir}/mydatabase.sql"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"
@@ -39,7 +40,7 @@ load test_helper
   local name="sh-import"
   local tmpdir="${MY_TMPDIR}/${name}"
   mkdir -p "${tmpdir}"
-  echo "mariadb -e \"create database mydatabase;\"" > "${tmpdir}/custom.sh"
+  echo "mariadb -e \"create database mydatabase;\"" >"${tmpdir}/custom.sh"
   create "${name}" "-e SKIP_INNODB=1 -v ${tmpdir}:/docker-entrypoint-initdb.d"
   wait_until_up "${name}"
   run client_query "${name}" "--database=mydatabase -e 'select 1;'"

--- a/test/innodb.sh
+++ b/test/innodb.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash_unit

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
 
 set -euo pipefail
 
@@ -11,8 +12,7 @@ create() {
 
 wait_until_up() {
   # $1: container name
-  until docker logs --tail 1 "${TEST_PREFIX}-${1}" 2>&1 | grep "Version:"
-  do
+  until docker logs --tail 1 "${TEST_PREFIX}-${1}" 2>&1 | grep "Version:"; do
     sleep 0.2
   done
 }


### PR DESCRIPTION
This way we don't have to invoke shellcheck twice.