### PR TITLE
feat: replace dependabot with renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    labels:
-      - "type: dependencies"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "timezone": "America/New_York",
+  "baseBranches": ["main"],
+  "dependencyDashboard": true,
+  "extends": [
+    "config:base",
+    "group:allNonMajor",
+    "helpers:disableTypesNodeMajor",
+    "schedule:earlyMondays"
+  ],
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+  "commitMessageAction": "",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "{{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{newVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
+  "regexManagers": [
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=\"(?<currentValue>.*)\"\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
+  "labels": ["dependencies"],
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
+  "prHeader": "",
+  "prFooter": "",
+  "semanticCommits": "enabled"
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - name: Install Actionlint
         env:
-          ACTIONLINT_VERSION: 1.6.10
+          ACTIONLINT_VERSION: 1.6.21
         run: |
           wget -q -O- "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | tar -x -z -C . actionlint && \
           mv actionlint /usr/local/bin

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,17 @@ on:
   pull_request:
 
 jobs:
+  validate-renovate-config:
+    name: validate renovate config
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: validate
+        uses: rinchsan/renovate-config-validator@v0.0.12
+        with:
+          pattern: ".github/renovate.json"
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: shellcheck
     steps:
       - uses: actions/checkout@v3.1.0
@@ -17,7 +26,7 @@ jobs:
       - name: test shell scripts
         run: shellcheck -S warning sh/*.sh test/*.{sh,bash}
   hadolint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: hadolint
     steps:
       - uses: actions/checkout@v3.1.0
@@ -26,7 +35,7 @@ jobs:
           error_level: 2
   actionlint:
     name: actionlint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Install Actionlint
@@ -39,7 +48,7 @@ jobs:
         run: |
           actionlint -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}{{end}}' -ignore 'SC2016:' .github/workflows/*.yml
   prettier:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: prettier
     steps:
       - uses: actions/checkout@v3.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.16
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE
 ARG VCS_REF
+# renovate: datasource=repology depName=alpine_3_16/mariadb versioning=loose
 ARG VERSION=10.6.9-r0
 
 LABEL \


### PR DESCRIPTION
Benefits:
- grouped updates
- opportunity to update variables in github actions
- track alpine updates for mariadb

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/43