### PR TITLE
chore: refactor actionlint output

### DIFF
--- a/.github/matcher-actionlint.json
+++ b/.github/matcher-actionlint.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,13 +40,15 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - name: Install Actionlint
         env:
-          ACTIONLINT_VERSION: 1.6.21
+          AL_VERSION: 1.6.21
+          AL_BASEURL: https://github.com/rhysd/actionlint/releases/download
         run: |
-          wget -q -O- "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | tar -x -z -C . actionlint && \
+          wget -q -O- "${AL_BASEURL}/v${AL_VERSION}/actionlint_${AL_VERSION}_linux_amd64.tar.gz" | tar -x -z -C . actionlint && \
           mv actionlint /usr/local/bin
       - name: Run Actionlint
         run: |
-          actionlint -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}{{end}}' -ignore 'SC2016:' .github/workflows/*.yml
+          echo "::add-matcher::.github/matcher-actionlint.json"
+          actionlint -color
   prettier:
     runs-on: ubuntu-22.04
     name: prettier


### PR DESCRIPTION
Switch from the deprecated `::set-output` to a problem matcher.