### PR TITLE
feat: improve renovatebot dependency matcher.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,10 +15,24 @@
   "regexManagers": [
     {
       "fileMatch": ["^Dockerfile$"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG VERSION=\"(?<currentValue>.*)\"\\s"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "matchStrings": ["^ARG VERSION=\"(?<currentValue>.*)\"$"],
+      "datasourceTemplate": "repology",
+      "depNameTemplate": "alpine_3_16/mariadb",
+      "versioningTemplate": "semver"
+    },
+    {
+      "fileMatch": ["^.github/workflows/lint.yml$"],
+      "matchStrings": ["^\\s+AL_VERSION:\\s(?<currentValue>.*)$"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "rhysd/actionlint",
+      "versioningTemplate": "semver"
+    },
+    {
+      "fileMatch": ["^.github/workflows/test.yml$"],
+      "matchStrings": ["^\\s+BU_VERSION:\\s(?<currentValue>.*)$"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "pgrange/bash_unit",
+      "versioningTemplate": "semver"
     }
   ],
   "labels": ["dependencies"],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,10 @@ jobs:
         run: docker pull jbergstroem/mariadb-client-alpine:latest
       - name: install bash_unit
         env:
-          BASH_UNIT_VERSION: 2.0.1
+          BU_VERSION: 2.0.1
+          BU_BASEURL: https://github.com/pgrange/bash_unit/archive/refs/tags
         run: |
-          wget -q -O- https://github.com/pgrange/bash_unit/archive/refs/tags/v${{ env.BASH_UNIT_VERSION }}.tar.gz | tar xz --strip=1 -C . && \
+          wget -q -O- ${{ env.BU_BASEURL }}/v${{ env.BU_VERSION }}.tar.gz | tar xz --strip=1 -C . && \
           sudo mv bash_unit /usr/local/bin
       - name: run suite
         run: bash_unit test/*.sh


### PR DESCRIPTION
1. Skip annotation and just define attributes in config instead
2. Monitor actionlint
3. Monitor bash_unit