### PR TITLE
feat: create a manual release workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,19 +16,19 @@
   "regexManagers": [
     {
       "fileMatch": ["^Dockerfile$"],
-      "matchStrings": ["^ARG VERSION=\"(?<currentValue>.*)\"$"],
+      "matchStrings": ["^ARG APK_VERSION=\"(?<currentValue>.*)\""],
       "datasourceTemplate": "repology",
       "depNameTemplate": "alpine_3_16/mariadb"
     },
     {
       "fileMatch": ["^.github/workflows/lint.yml$"],
-      "matchStrings": ["^\\s+AL_VERSION:\\s(?<currentValue>.*)$"],
+      "matchStrings": ["^\\s+AL_VERSION:\\s(?<currentValue>.*)"],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "rhysd/actionlint"
     },
     {
       "fileMatch": ["^.github/workflows/test.yml$"],
-      "matchStrings": ["^\\s+BU_VERSION:\\s(?<currentValue>.*)$"],
+      "matchStrings": ["^\\s+BU_VERSION:\\s(?<currentValue>.*)"],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "pgrange/bash_unit"
     },

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,10 @@
-name: lint
+name: Lint
 on:
   pull_request:
 
 jobs:
   validate-renovate-config:
-    name: validate renovate config
+    name: Validate renovate config
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.1.0
@@ -14,30 +14,30 @@ jobs:
           pattern: ".github/renovate.json"
   shellcheck:
     runs-on: ubuntu-22.04
-    name: shellcheck
+    name: Shellcheck
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: install shellcheck
+      - name: Install Shellcheck
         env:
           SC_VERSION: v0.8.0
           SC_BASEURL: https://github.com/koalaman/shellcheck/releases/download
         run: |
           wget -qO- "${{ env.SC_BASEURL }}/${{ env.SC_VERSION }}/shellcheck-${{ env.SC_VERSION }}.linux.x86_64.tar.xz" | tar -xJ
           sudo cp "shellcheck-${{ env.SC_VERSION }}/shellcheck" /usr/local/bin/
-      - name: test shell scripts
+      - name: Verify shell scripts
         run: |
           echo "::add-matcher::.github/matcher-shellcheck.json"
           shellcheck -f gcc -S warning sh/*.sh test/*.{sh,bash}
   hadolint:
     runs-on: ubuntu-22.04
-    name: hadolint
+    name: Hadolint
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: jbergstroem/hadolint-gh-action@v1.9.1
         with:
           error_level: 2
   actionlint:
-    name: actionlint
+    name: Actionlint
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.1.0
@@ -54,13 +54,13 @@ jobs:
           actionlint -color
   prettier:
     runs-on: ubuntu-22.04
-    name: prettier
+    name: Prettier
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-node@v3.5.1
         with:
           node-version: 18
-      - name: install prettier
+      - name: Install prettier
         run: npm install -g prettier
-      - name: run prettier
+      - name: Run prettier
         run: prettier -c .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      override:
+        type: boolean
+        description: Replace existing tag/version
+        default: false
+      latest:
+        type: boolean
+        description: Update `:latest` on docker hub
+        default: false
+
+jobs:
+  sanity_check:
+    runs-on: ubuntu-22.04
+    name: Prepare version
+    outputs:
+      tag: ${{ steps.extract.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3.1.0
+        with:
+          # get all tags
+          fetch-depth: 0
+      - name: Extract tag from Dockerfile
+        shell: bash
+        id: extract
+        run: |
+          echo tag="$(sed -rn 's/^ARG APK_VERSION=\"([0-9]+\.[0-9]+\.[0-9]+).*\"$/\1/p' Dockerfile)" >> "$GITHUB_OUTPUT"\
+      - name: Verify tag extraction
+        shell: bash
+        run: |
+          [[ -z "${{ steps.extract.outputs.tag }}" ]] && echo "Could not extract current version" && exit 1 || exit 0
+      - name: Check if tag exists
+        shell: bash
+        if: ${{ ! inputs.override }}
+        env:
+          TAG_URL: "https://hub.docker.com/v2/repositories/jbergstroem/mariadb-alpine/tags?page_size=100"
+        run: |
+          [[ $(git tag -l "${{ steps.extract.outputs.tag }}") || $(curl -L -s "${{ env.TAG_URL }}" | jq -r '.results[] | select(.name=="${{ steps.extract.outputs.tag }}")') ]] && \
+          echo "Tag already exists. Quitting." && exit 1 || exit 0
+  test:
+    name: Run e2e tests
+    needs:
+      - sanity_check
+    uses: ./.github/workflows/test.yml
+
+  release:
+    name: Build and push multi-platform
+    runs-on: ubuntu-22.04
+    needs:
+      - sanity_check
+      - test
+    env:
+      platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/s390x,linux/ppc64le
+      image: jbergstroem/mariadb-alpine
+      ref_url: ${{ github.api_url }}/repos/${{ github.repository }}/git/refs
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+        with:
+          platforms: ${{ env.platforms }}
+      - name: Enable latest tag
+        if: ${{ inputs.latest }}
+        run: echo LATEST=",${{ env.image }}:latest" >> "$GITHUB_ENV"
+      - name: Set build args
+        run: |
+          echo BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+          echo BUILD_REF="$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+      - name: Build containers for all platforms
+        uses: docker/build-push-action@v3.2.0
+        with:
+          platforms: ${{ env.platforms }}
+          tags: ${{ env.image }}:${{ needs.sanity_check.outputs.tag }}${{ env.LATEST }}
+          push: false
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REF=${{ env.BUILD_REF }}
+            BUILD_VERSION=${{ needs.sanity_check.outputs.tag }}
+      - name: Remove old git reference
+        if: ${{ inputs.override }}
+        run: |
+          curl -s -X DELETE "${{ env.ref_url }}/tags/${{ needs.sanity_check.outputs.tag }}" \
+            -H "Authorization: token ${{ github.token }}"
+      - name: Create git reference
+        run: |
+          curl -s -X POST "${{ env.ref_url }}" \
+            -H "Authorization: token ${{ github.token }}" \
+            -d '{ "ref": "refs/tags/${{ needs.sanity_check.outputs.tag }}", "sha": "${{ github.sha }}" }' | \
+            grep "Reference already exists" && echo "Tag already exists. Quitting." && exit 1 || exit 0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push to Docker hub
+        uses: docker/build-push-action@v3.2.0
+        with:
+          platforms: ${{ env.platforms }}
+          tags: ${{ env.image }}:${{ needs.sanity_check.outputs.tag }}${{ env.LATEST }}
+          push: true
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            BUILD_REF=${{ env.BUILD_REF }}
+            BUILD_VERSION=${{ needs.sanity_check.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,27 +1,29 @@
-name: test
-on: pull_request
+name: Test
+on:
+  - pull_request
+  - workflow_call
 
 jobs:
-  build:
-    name: container e2e tests
+  test:
+    name: E2E Tests
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.1.0
-      - name: assign version for usage
+      - name: Assign version for usage
         id: assign
         run: echo IMAGE_VERSION="$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-      - name: build the container
+      - name: Build container
         run: sh/build-image.sh
         env:
           VERSION: ${{ env.IMAGE_VERSION }}
-      - name: download cli
+      - name: Download mariadb cli
         run: docker pull jbergstroem/mariadb-client-alpine:latest
-      - name: install bash_unit
+      - name: Install bash_unit
         env:
           BU_VERSION: v2.0.1
           BU_BASEURL: https://github.com/pgrange/bash_unit/archive/refs/tags
         run: |
           wget -q -O- ${{ env.BU_BASEURL }}/${{ env.BU_VERSION }}.tar.gz | tar xz --strip=1 -C . && \
           sudo mv bash_unit /usr/local/bin
-      - name: run suite
+      - name: Run suite
         run: bash_unit test/*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
 FROM alpine:3.16
 
-# https://github.com/opencontainers/image-spec/blob/master/annotations.md
 ARG BUILD_DATE
-ARG VCS_REF
-# renovate: datasource=repology depName=alpine_3_16/mariadb versioning=loose
-ARG VERSION="10.6.10-r0"
+ARG BUILD_REF
+ARG BUILD_VERSION
+ARG APK_VERSION="10.6.10-r0"
 
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL \
   org.opencontainers.image.authors="Johan Bergström <bugs@bergstroem.nu>" \
   org.opencontainers.image.created="$BUILD_DATE" \
   org.opencontainers.image.description="A tiny MariaDB container" \
   org.opencontainers.image.licenses="MIT" \
-  org.opencontainers.image.revision="$VCS_REF" \
+  org.opencontainers.image.revision="$BUILD_REF" \
   org.opencontainers.image.source="https://github.com/jbergstroem/mariadb-alpine" \
   org.opencontainers.image.title="jbergstroem/mariadb-alpine" \
   org.opencontainers.image.url="https://github.com/jbergstroem/mariadb-alpine" \
   org.opencontainers.image.vendor="Johan Bergström" \
-  org.opencontainers.image.version="$VERSION"
+  org.opencontainers.image.version="$BUILD_VERSION"
 
 SHELL ["/bin/ash", "-euo", "pipefail", "-c"]
 
 RUN \
-  apk add --no-cache mariadb=${VERSION} && \
+  apk add --no-cache mariadb=${APK_VERSION} && \
   TO_KEEP=$(echo " \
     etc/ssl/certs/ca-certificates.crt$ \
     usr/bin/mariadbd$ \

--- a/sh/build-image.sh
+++ b/sh/build-image.sh
@@ -4,9 +4,11 @@
 IMAGE=${IMAGE:-jbergstroem/mariadb-alpine}
 SHORT_SHA=$(git rev-parse --short HEAD)
 DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+MARIADB_VERSION="$(sed -rn 's/^ARG APK_VERSION=\"([0-9]+\.[0-9]+\.[0-9]+).*\"$/\1/p' Dockerfile)"
 VERSION=${VERSION:-${SHORT_SHA}}
 
 docker image build \
   --build-arg BUILD_DATE="${DATE}" \
-  --build-arg VCS_REF="${SHORT_SHA}" \
+  --build-arg BUILD_REF="${SHORT_SHA}" \
+  --build-arg BUILD_VERSION="${MARIADB_VERSION}" \
   -t "${IMAGE}:${VERSION}" .


### PR DESCRIPTION
The logic is as follows:
1. Extract mariadb version from apk
2. Build and test container on amd64
3. Push to docker hub and github

Options:
- [x] Ignore existing tags on github or docker hub. This disables sanity checks for not overwriting or replacing existing tags.
- [x] Push a new `:latest` tag.

With this workflow, mariadb-alpine now supports 7 architectures:
- linux/amd64
- linux/arm/v6
- linux/arm/v7
- linux/arm64
- linux/386
- linux/s390x
- linux/ppc64le

Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/29
Fixes: https://github.com/jbergstroem/mariadb-alpine/issues/17