### PR TITLE
fix: exclude `v` from versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,8 @@
         "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls \"https://github.com/(?<depName>.*?)/releases/download.*",
         "https://github\\.com/(?<depName>.*?)/archive/refs/tags/(?<currentValue>.*?)\\.tar\\.gz"
       ],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["^\\.github/workflows/[^/]+\\.yml$"],

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - name: Install Shellcheck
         env:
-          version: "v0.8.0"
-        run: curl -Ls "https://github.com/koalaman/shellcheck/releases/download/${{ env.version }}/shellcheck-${{ env.version }}.linux.x86_64.tar.xz" | sudo tar -x -J --wildcards --strip-components=1 -C /usr/local/bin "shellcheck*/shellcheck"
+          version: "0.8.0"
+        run: curl -Ls "https://github.com/koalaman/shellcheck/releases/download/v${{ env.version }}/shellcheck-v${{ env.version }}.linux.x86_64.tar.xz" | sudo tar -x -J --wildcards --strip-components=1 -C /usr/local/bin "shellcheck*/shellcheck"
       - name: Verify shell scripts
         run: |
           echo "::add-matcher::.github/matcher-shellcheck.json"


### PR DESCRIPTION
Fixes an issue where `v` was handled inconsistently as part of updating the version string.

Refs: https://github.com/jbergstroem/mariadb-alpine/pull/165