### PR TITLE
fix: correct reference for helper file in tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Verify shell scripts
         run: |
           echo "::add-matcher::.github/matcher-shellcheck.json"
-          shellcheck -f gcc -S warning sh/*.sh test/*.{sh,bash}
+          shellcheck -x -f gcc -S warning sh/*.sh test/*.{sh,bash}
   hadolint:
     runs-on: ubuntu-22.04
     name: Hadolint

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash_unit
 
-# shellcheck source=_helper.sh
+# shellcheck source=test/_helper.bash
 . _helper.bash
 
 suite_name="basic"

--- a/test/config.sh
+++ b/test/config.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash_unit
 # shellcheck shell=bash
 
-# shellcheck source=_helper.sh
+# shellcheck source=test/_helper.bash
 . _helper.bash
 
 suite_name="config"

--- a/test/import.sh
+++ b/test/import.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash_unit
 
-# shellcheck source=_helper.sh
+# shellcheck source=test/_helper.bash
 . _helper.bash
 
 suite_name="import"

--- a/test/innodb.sh
+++ b/test/innodb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash_unit
 
-# shellcheck source=_helper.sh
+# shellcheck source=test/_helper.bash
 . _helper.bash
 
 suite_name="innodb"


### PR DESCRIPTION
Minor nit to make shellcheck happy, the file was incorrectly referenced. It is also assumed that shellcheck is invoked from the root of the directory.