### PR TITLE
fix: use `prettyVersion` for printing version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,6 @@
   "enabledManagers": ["dockerfile", "github-actions", "regex"],
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
-  "commitMessageExtra": "{{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{newVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
   "regexManagers": [
     {
       "fileMatch": ["^Dockerfile$"],


### PR DESCRIPTION
Newer default templates in renovatebot's title uses `prettyVersion` which should cover what I want to achieve with titles.

Refs: https://github.com/renovatebot/renovate/issues/13299#issuecomment-1200899853