### PR TITLE
fix: override matchManager default

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,13 @@
   "enabledManagers": ["dockerfile", "github-actions", "regex"],
   "commitMessageAction": "",
   "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "{{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessageTopic": "{{depName}}"
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^Dockerfile$"],


### PR DESCRIPTION
Some matchManagers has rules that overrides any global default set. These are overridable with packageRules.

Refs: https://github.com/renovatebot/renovate/issues/18828