### PR TITLE
feat: mariadb 10.6.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG BUILD_DATE
 ARG BUILD_REF
 ARG BUILD_VERSION
-ARG APK_VERSION="10.6.10-r0"
+ARG APK_VERSION="10.6.11-r0"
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL \


### PR DESCRIPTION
Also, bump to Alpine Linux 3.17. The size increase (~1.5Mb uncompressed) unfortunately comes from this layer.

---

```
-----Size-----

$ container-diff diff daemon://jbergstroem/mariadb-alpine: c80632a daemon://jbergstroem/mariadb-alpine:latest

Image size difference between jbergstroem/mariadb-alpine:c80632a and jbergstroem/mariadb-alpine:latest:
SIZE1        SIZE2
36M          33.6M

$ container-diff diff daemon://jbergstroem/mariadb-alpine:c80632a daemon://jbergstroem/mariadb-alpine:latest --type=file
These entries have been added to jbergstroem/mariadb-alpine:c80632a:
FILE                                   SIZE
/etc/terminfo/k/kitty                  3.3K
/lib/libcrypto.so.1.1                  2.5M
/lib/libssl.so.1.1                     511.4K
/lib/libz.so.1.2.12                    97.9K
/sbin/mkmntdirs                        13.7K
/usr/lib/engines-1.1                   61.6K
/usr/lib/engines-1.1/afalg.so          22.2K
/usr/lib/engines-1.1/capi.so           13.5K
/usr/lib/engines-1.1/padlock.so        25.9K
/usr/lib/libaio.so.1.0.1               13.8K
/usr/lib/libcrypto.so.1.1              26B
/usr/lib/liblzma.so.5.2.5              133.7K
/usr/lib/libnghttp2.so.14.21.2         141.8K
/usr/lib/libssl.so.1.1                 23B
/usr/lib/libstdc++.so.6.0.29           1.8M
/usr/lib/libxml2.so.2.9.14             1.2M

These entries have been deleted from jbergstroem/mariadb-alpine:c80632a:
FILE                                      SIZE
/etc/nsswitch.conf                        205B
/etc/ssl1.1                               31B
/etc/ssl1.1/cert.pem                      17B
/etc/ssl1.1/certs                         14B
/etc/terminfo/x/xterm-kitty               3.3K
/lib/apk/exec                             0
/lib/libcrypto.so.3                       3.7M
/lib/libssl.so.3                          588K
/lib/libz.so.1.2.13                       97.9K
/usr/lib/engines-3                        104K
/usr/lib/engines-3/afalg.so               22.1K
/usr/lib/engines-3/capi.so                13.5K
/usr/lib/engines-3/loader_attic.so        46.5K
/usr/lib/engines-3/padlock.so             21.9K
/usr/lib/libaio.so.1.0.2                  13.8K
/usr/lib/libcrypto.so.3                   24B
/usr/lib/liblzma.so.5.2.8                 161.8K
/usr/lib/libnghttp2.so.14.24.1            157.9K
/usr/lib/libssl.so.3                      21B
/usr/lib/libstdc++.so.6.0.30              2.3M
/usr/lib/libxml2.so.2.10.3                1.1M
/usr/lib/ossl-modules                     101.9K
/usr/lib/ossl-modules/legacy.so           101.9K

These entries have been changed between jbergstroem/mariadb-alpine:c80632a and jbergstroem/mariadb-alpine:latest:
FILE                                           SIZE1         SIZE2
/usr/bin/mariadbd                              19.9M         20M
/usr/share/mariadb/fill_help_tables.sql        2.1M          1.6M
/bin/busybox                                   821.7K        821.7K
/usr/lib/libpcre2-8.so.0.11.0                  642.1K        642.1K
/lib/ld-musl-x86_64.so.1                       602.5K        590.5K
/usr/lib/libbrotlienc.so.1.0.9                 582.2K        522.2K
/usr/lib/libcurl.so.4.8.0                      509.7K        493.5K
/usr/lib/libncursesw.so.6.3                    367K          367K
/lib/libapk.so.3.12.0                          179.7K        179.7K
/usr/lib/libbrotlicommon.so.1.0.9              133.8K        133.7K
/usr/lib/libgcc_s.so.1                         117.8K        93.8K
/usr/bin/scanelf                               81.9K         77.9K
/usr/share/mariadb/english/errmsg.sys          75.9K         75.9K
/sbin/apk                                      67.9K         68K
/usr/lib/libformw.so.6.3                       63K           63K
/usr/lib/libbrotlidec.so.1.0.9                 49.7K         41.7K
/lib/apk/db/installed                          48.9K         48.5K
/usr/bin/getent                                47.3K         47.5K
/usr/bin/getconf                               34.1K         33.9K
/usr/lib/libmenuw.so.6.3                       34K           34K
/usr/bin/iconv                                 23.6K         23.7K
/usr/bin/mariadb-install-db                    21.5K         21.5K
/usr/lib/libpanelw.so.6.3                      17.6K         17.6K
/usr/bin/ssl_client                            14K           14K
/usr/lib/libpcre2-posix.so.3.0.2               13.8K         13.7K
/etc/services                                  12.5K         12.7K
/etc/ssl/openssl.cnf                           12K           10.7K
/etc/ssl/openssl.cnf.dist                      12K           10.7K
/etc/ssl/misc/CA.pl                            7.9K          7.4K
/etc/ssl/misc/tsget.pl                         6.6K          6.4K
/etc/terminfo/x/xterm-256color                 3.8K          3.8K
/etc/terminfo/x/xterm                          3.7K          3.7K
/usr/share/udhcpc/default.script               3.6K          3.6K
/etc/protocols                                 3.1K          2.9K
/etc/terminfo/t/terminology-1.0.0              3.1K          3K
/etc/terminfo/p/putty-256color                 2.4K          2.4K
/etc/terminfo/t/terminology-0.6.1              2.3K          2.3K
/etc/terminfo/p/putty                          2.3K          2.3K
/etc/terminfo/t/terminator                     1.7K          1.7K
/etc/terminfo/v/vt100                          1.3K          1.2K
/etc/terminfo/v/vt102                          1.2K          1.2K
/etc/profile                                   846B          857B
/etc/shadow                                    449B          449B
/etc/motd                                      284B          283B
/lib/apk/db/triggers                           212B          212B
/etc/os-release                                192B          188B
/etc/apk/repositories                          103B          103B
/etc/secfixes.d/alpine                         97B           97B
/etc/apk/world                                 78B           78B
/etc/issue                                     54B           54B
/usr/lib/libnghttp2.so.14                      21B           21B
/usr/lib/libstdc++.so.6                        19B           19B
/usr/lib/libxml2.so.2                          17B           17B
/usr/lib/liblzma.so.5                          16B           16B
/usr/lib/libaio.so.1                           15B           15B
/lib/libz.so.1                                 14B           14B
/etc/alpine-release                            11B           7B
```