### PR TITLE
feat: bundle a mariadb client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ LABEL \
 SHELL ["/bin/ash", "-euo", "pipefail", "-c"]
 
 RUN \
-  apk add --no-cache mariadb=${APK_VERSION} && \
+  apk add --no-cache mariadb=${APK_VERSION} mariadb-client=${APK_VERSION} && \
   TO_KEEP=$(echo " \
     etc/ssl/certs/ca-certificates.crt$ \
+    usr/bin/mariadb$ \
     usr/bin/mariadbd$ \
     usr/bin/getconf$ \
     usr/bin/getent$ \
@@ -37,7 +38,7 @@ RUN \
     usr/share/mariadb/mysql_sys_schema.sql$ \
     usr/share/mariadb/fill_help_tables.sql$" | \
     tr -d " \t\n\r" | sed -e 's/usr/|usr/g' -e 's/^.//') && \
-  INSTALLED=$(apk info -q -L mariadb-common mariadb linux-pam ca-certificates | grep "\S") && \
+  INSTALLED=$(apk info -q -L mariadb-common mariadb mariadb-client linux-pam ca-certificates | grep "\S") && \
   for path in $(echo "${INSTALLED}" | grep -v -E "${TO_KEEP}"); do \
     eval rm -rf "${path}"; \
   done && \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Licensed under [MIT][4].
 - Conveniently skip InnoDB: Gain a few seconds on startup
 - Reduce default settings for InnoDB: production deployments should have their on `my.cnf`
 - Simple and fast shutdowns: Both `CTRL+C` in interactive mode and `docker stop` does the job
+- Bundles a mariadb client: `docker run -it --entrypoint mariadb jbergstoem/mariadb-alpine`
 
 ## Quickstart
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,7 +127,7 @@ $ docker run --network db --name db -d -e SKIP_INNODB=1 -p 3306:3306 jbergstroem
 733de227b9a7b54039e13be922e8c7f13e509665377e402db9d56fd2f86415b3
 $ docker run -it alpine
 / # apk add --no-cache -q mariadb mariadb-client tzdata
-/ # mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root -h db mysql
+/ # mysql_tzinfo_to_sql /usr/share/zoneinfo | mariadb -u root -h db mysql
 ```
 
 As you can imagine, this is easy to script or incorporate as part of a container orchestration.

--- a/sh/run.sh
+++ b/sh/run.sh
@@ -53,15 +53,6 @@ if [ -z "$(ls -A /var/lib/mysql/ 2>/dev/null)" ]; then
   # pass scripts to it. Since we're already up an running we might as well
   # pass the init script and avoid it later.
   if [ "$(ls -A /docker-entrypoint-initdb.d 2>/dev/null)" ]; then
-    # Download the mysql client since we will need it to feed data to our server.
-    # This kind of sucks but seems unavoidable since using --init-file
-    # has size restrictions:
-    #   ERROR: 1105  Boostrap file error. Query size exceeded 20000 bytes near <snip>
-    # The other option is to embed the client, but since one of the goals is to
-    # Strive for the smallest possible size, this seems to be the only option.
-    echo "init: installing mysql client"
-    apk add -q --no-cache mariadb-client
-
     MYSQL_CMD="mariadb -h 127.0.0.1"
 
     # Start a mariadbd we will use to pass init stuff to. Can't use the same options
@@ -105,10 +96,6 @@ if [ -z "$(ls -A /var/lib/mysql/ 2>/dev/null)" ]; then
     kill -s TERM "${PID}"
     wait "${PID}"
 
-    # Clean up
-    rm "${MARIADBD_OUTPUT}"
-    echo "init: removing mysql client"
-    apk del -q --no-cache mariadb-client
   else
     MYSQLD_OPTS="${MYSQLD_OPTS} --init-file=/tmp/init"
   fi

--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -8,7 +8,7 @@ IMAGE_VERSION=${IMAGE_VERSION:-latest}
 TEST_PREFIX="mariadb-alpine-test"
 
 # shellcheck disable=SC2034
-CLIENT="docker run --rm jbergstroem/mariadb-client-alpine:latest"
+CLIENT="docker run --rm --entrypoint mariadb jbergstroem/mariadb-alpine:${IMAGE_VERSION}"
 
 if ((BASH_VERSINFO[0] < 4)); then
   echo "You need Bash 4 or newer to run this test suite"


### PR DESCRIPTION
Simplifies tests, usage and loading fixtures at the expense of ~2Mb uncompressed disk space.

Usage:
```console
$ docker run -it --entrypoint mariadb jbergstroem/mariadb-alpine
ERROR 2002 (HY000): Can't connect to local server through socket '/run/mysqld/mysqld.sock' (2)
```

Closes: https://github.com/jbergstroem/mariadb-alpine/discussions/140