### PR TITLE
fix: match optional output in renovate match

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,7 +29,7 @@
     {
       "fileMatch": ["^\\.github/workflows/[^/]+\\.yml$"],
       "matchStrings": [
-        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls \"https://github.com/(?<depName>.*?)/releases/download.*",
+        "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
         "https://github\\.com/(?<depName>.*?)/archive/refs/tags/(?<currentValue>.*?)\\.tar\\.gz"
       ],
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
shfmt passes extra options to curl which makes renovate not match it.