### PR TITLE
fix: move "v" outside bash_unit versioning match

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,6 +46,10 @@
       "commitMessageTopic": "shellcheck"
     },
     {
+      "matchPackagePatterns": ["bash_unit"],
+      "commitMessageTopic": "bash_unit"
+    },
+    {
       "matchPackagePatterns": ["^alpine_\\d+_\\d+/mariadb"],
       "commitMessageTopic": "mariadb"
     }
@@ -62,7 +66,7 @@
       "fileMatch": ["^\\.github/workflows/[^/]+\\.yml$"],
       "matchStrings": [
         "version: \"(?<currentValue>.*?)\"\\s+run: curl -Ls( -o \\w+)? \"https://github.com/(?<depName>.*?)/releases/download.*",
-        "https://github\\.com/(?<depName>.*?)/archive/refs/tags/(?<currentValue>.*?)\\.tar\\.gz"
+        "https://github\\.com/(?<depName>.*?)/archive/refs/tags/v(?<currentValue>.*?)\\.tar\\.gz"
       ],
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"


### PR DESCRIPTION
This way, renovate should properly bump the dependency.