### PR TITLE
feat: use mariadb client for healthchecks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !sh/run.sh
+!sh/health.sh
 !sh/clean.sh
 !sh/resolveip.sh
 !sh/my_print_defaults.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN \
 # my_print_defaults should cover 95% of cases since it doesn't properly do recursion
 COPY sh/resolveip.sh /usr/bin/resolveip
 COPY sh/my_print_defaults.sh /usr/bin/my_print_defaults
-COPY sh/run.sh /run.sh
+COPY sh/run.sh sh/health.sh /
 # Used in run.sh as a default config
 COPY my.cnf /tmp/my.cnf
 
@@ -62,7 +62,7 @@ COPY my.cnf /tmp/my.cnf
 # Since we have no clients, we can't really connect to it and check.
 #
 # Below is in my opinion better than no health check.
-HEALTHCHECK --start-period=5s CMD pgrep mariadbd
+HEALTHCHECK --start-period=5s CMD /health.sh
 
 VOLUME ["/var/lib/mysql"]
 ENTRYPOINT ["/run.sh"]

--- a/sh/health.sh
+++ b/sh/health.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# shellcheck shell=dash
+set -eo pipefail
+
+CHECK="mariadb"
+
+# prefer root if available
+if [ -n "${MYSQL_ROOT_PASSWORD}" ]; then
+  CHECK="${CHECK} --user=root --password=${MYSQL_ROOT_PASSWORD}"
+else
+  [ -n "${MYSQL_DATABASE}" ] && CHECK="${CHECK} --database=${MYSQL_DATABASE}"
+  [ -n "${MYSQL_USERNAME}" ] && CHECK="${CHECK} --user=${MYSQL_USERNAME}"
+  [ -n "${MYSQL_PASSWORD}" ] && CHECK="${CHECK} --password=${MYSQL_PASSWORD}"
+fi
+CHECK="${CHECK} -e 'select 1;'"
+
+eval ${CHECK}


### PR DESCRIPTION
Instead of grepping for an existing daemon, we now run a query similar to how `mysqladmin` does it (connects to server/db and runs `select 1`).

### Todo

- [ ] review how others deal with then case of setting up a database with user/pass/root pass but then remove from a startup
- [ ] tests (painful! takes ~15s before it responds as healthy via ` docker inspect --format "{{json .State.Health }}"` - I could just lean on similar query / logic)