### PR TITLE
chore: stick to version majors

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run shell script
         run: sh/generate-dockerhub-readme.sh
       - name: Update Docker Hub readme and description
-        uses: peter-evans/dockerhub-description@v4.0.0
+        uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: validate
-        uses: rinchsan/renovate-config-validator@v0.0.12
-        with:
-          pattern: ".github/renovate.json"
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install -g renovate
+      - name: Validate config
+        run: renovate-config-validator .github/renovate.json
+
   shellcheck:
     runs-on: ubuntu-22.04
     name: Shellcheck
@@ -25,14 +26,16 @@ jobs:
         run: |
           echo "::add-matcher::.github/matcher-shellcheck.json"
           shellcheck -x -f gcc -S warning sh/*.sh test/*.{sh,bash}
+
   hadolint:
     runs-on: ubuntu-22.04
     name: Hadolint
     steps:
       - uses: actions/checkout@v4
-      - uses: jbergstroem/hadolint-gh-action@v1.12.1
+      - uses: jbergstroem/hadolint-gh-action@v1
         with:
           error_level: 2
+
   actionlint:
     name: Actionlint
     runs-on: ubuntu-22.04
@@ -46,18 +49,15 @@ jobs:
         run: |
           echo "::add-matcher::.github/matcher-actionlint.json"
           actionlint -color
+
   prettier:
     runs-on: ubuntu-22.04
     name: Prettier
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.1
-        with:
-          node-version: "18.11.0"
-      - name: Install prettier
-        run: npm install -g prettier
-      - name: Run prettier
-        run: prettier -c .
+      - uses: oven-sh/setup-bun@v1
+      - run: bunx prettier -c .
+
   shfmt:
     name: Shfmt
     runs-on: ubuntu-22.04
@@ -69,3 +69,11 @@ jobs:
         run: curl -Ls -o shfmt "https://github.com/mvdan/sh/releases/download/v${{ env.version }}/shfmt_v${{ env.version }}_linux_amd64" && chmod +x shfmt && sudo mv shfmt /usr/local/bin
       - name: Lint shell scripts
         run: shfmt -i 2 -d sh/*.sh test/*.sh
+
+  typos:
+    name: Typos
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for typos
+        uses: crate-ci/typos@v1.18.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           [[ $(git tag -l "${{ steps.extract.outputs.tag }}") || $(curl -L -s "${{ env.TAG_URL }}" | jq -r '.results[] | select(.name=="${{ steps.extract.outputs.tag }}")') ]] && \
           echo "Tag already exists. Quitting." && exit 1 || exit 0
+
   test:
     name: Run e2e tests
     needs:

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: TODO to Issue
-        uses: alstr/todo-to-issue-action@v4.12.1
+        uses: alstr/todo-to-issue-action@v4
         with:
           CLOSE_ISSUES: false


### PR DESCRIPTION
Reduce the update noise by only using majors in CI. While at it, use Bun to validate renovate config and run prettier; shaves a few seconds off runtime.

Finally, add a job that looks for typos.

Closes: https://github.com/jbergstroem/mariadb-alpine/pull/278